### PR TITLE
chore(github): update GitHub organization name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We try to make it easy, and all contributions, even the smaller ones, are more t
 This includes bug reports, fixes, documentation, examples...
 But first, read this page (including the small print at the end).
 
-Contributions are available on https://github.com/Orange-OpenSource/PowerDNS-Operator
+Contributions are available on https://github.com/powerdns-operator/PowerDNS-Operator
 
 ## Legal
 

--- a/DEV_SETUP.md
+++ b/DEV_SETUP.md
@@ -104,5 +104,5 @@ its dependencies.
 Users can just run kubectl apply -f <URL for YAML BUNDLE> to install the project, i.e.:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/orange-opensource/powerdns-operator/<tag or branch>/dist/install.yaml
+kubectl apply -f https://raw.githubusercontent.com/powerdns-operator/powerdns-operator/<tag or branch>/dist/install.yaml
 ```

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+Copyright (c) PowerDNS-Operator contributors
+Copyright (c) 2025 Orange Business Services SA
+
+This project is licensed under the Apache License, Version 2.0.

--- a/PROJECT
+++ b/PROJECT
@@ -6,14 +6,14 @@ domain: cav.enablers.ob
 layout:
 - go.kubebuilder.io/v4
 projectName: powerdns-operator
-repo: github.com/orange-opensource/powerdns-operator
+repo: github.com/powerdns-operator/powerdns-operator
 resources:
 - api:
     crdVersion: v1
   domain: cav.enablers.ob
   group: dns
   kind: Zone
-  path: github.com/orange-opensource/powerdns-operator/api/v1alpha1
+  path: github.com/powerdns-operator/powerdns-operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -21,7 +21,7 @@ resources:
   domain: cav.enablers.ob
   group: dns
   kind: RRset
-  path: github.com/orange-opensource/powerdns-operator/api/v1alpha1
+  path: github.com/powerdns-operator/powerdns-operator/api/v1alpha1
   version: v1alpha1
 - api:
     crdVersion: v1
@@ -30,7 +30,7 @@ resources:
   domain: cav.enablers.ob
   group: dns
   kind: Zone
-  path: github.com/orange-opensource/powerdns-operator/api/v1alpha2
+  path: github.com/powerdns-operator/powerdns-operator/api/v1alpha2
   version: v1alpha2
 - api:
     crdVersion: v1
@@ -39,7 +39,7 @@ resources:
   domain: cav.enablers.ob
   group: dns
   kind: RRset
-  path: github.com/orange-opensource/powerdns-operator/api/v1alpha2
+  path: github.com/powerdns-operator/powerdns-operator/api/v1alpha2
   version: v1alpha2
 - api:
     crdVersion: v1
@@ -47,7 +47,7 @@ resources:
   domain: cav.enablers.ob
   group: dns
   kind: ClusterZone
-  path: github.com/orange-opensource/powerdns-operator/api/v1alpha2
+  path: github.com/powerdns-operator/powerdns-operator/api/v1alpha2
   version: v1alpha2
 - api:
     crdVersion: v1
@@ -55,6 +55,6 @@ resources:
   domain: cav.enablers.ob
   group: dns
   kind: ClusterRRset
-  path: github.com/orange-opensource/powerdns-operator/api/v1alpha2
+  path: github.com/powerdns-operator/powerdns-operator/api/v1alpha2
   version: v1alpha2
 version: "3"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ EOF
 Then, install the latest (or change `main` to the disired `tag`) operator using the following command:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/orange-opensource/powerdns-operator/main/dist/install.yaml
+kubectl apply -f https://raw.githubusercontent.com/powerdns-operator/powerdns-operator/main/dist/install.yaml
 ```
 
 ### Usage

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/api/v1alpha1/rrset_types.go
+++ b/api/v1alpha1/rrset_types.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/api/v1alpha1/zone_types.go
+++ b/api/v1alpha1/zone_types.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -3,7 +3,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/api/v1alpha2/clusterrrset_types.go
+++ b/api/v1alpha2/clusterrrset_types.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/api/v1alpha2/clusterzone_types.go
+++ b/api/v1alpha2/clusterzone_types.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/api/v1alpha2/generic_rrset.go
+++ b/api/v1alpha2/generic_rrset.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/api/v1alpha2/generic_zone.go
+++ b/api/v1alpha2/generic_zone.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/api/v1alpha2/groupversion_info.go
+++ b/api/v1alpha2/groupversion_info.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/api/v1alpha2/rrset_types.go
+++ b/api/v1alpha2/rrset_types.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/api/v1alpha2/zone_types.go
+++ b/api/v1alpha2/zone_types.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/api/v1alpha2/zz_generated.deepcopy.go
+++ b/api/v1alpha2/zz_generated.deepcopy.go
@@ -3,7 +3,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,11 +28,11 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	"github.com/orange-opensource/powerdns-operator/internal/controller"
+	"github.com/powerdns-operator/powerdns-operator/internal/controller"
 
 	powerdns "github.com/joeig/go-powerdns/v3"
 
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -36,15 +36,15 @@ EOF
 Install the latest version using the following command:
 
 ```bash
-kubectl apply -f https://github.com/Orange-OpenSource/PowerDNS-Operator/releases/latest/download/bundle.yaml
+kubectl apply -f https://github.com/powerdns-operator/PowerDNS-Operator/releases/latest/download/bundle.yaml
 ```
 
 Or you can specify a specific version (e.g. `v0.1.0`):
 
 ```bash
-kubectl apply -f https://github.com/Orange-OpenSource/PowerDNS-Operator/releases/download/v0.1.0/bundle.yaml
+kubectl apply -f https://github.com/powerdns-operator/PowerDNS-Operator/releases/download/v0.1.0/bundle.yaml
 ```
 
 ## Installing with Helm
 
-A Helm chart is available on a [specific project](https://github.com/orange-opensource/PowerDNS-Operator-helm-chart).
+A Helm chart is available on a [specific project](https://github.com/powerdns-operator/PowerDNS-Operator-helm-chart).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/orange-opensource/powerdns-operator
+module github.com/powerdns-operator/powerdns-operator
 
 go 1.24.0
 

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/internal/controller/clusterrrset_controller.go
+++ b/internal/controller/clusterrrset_controller.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 )
 
 // ClusterRRsetReconciler reconciles a ClusterRRset object

--- a/internal/controller/clusterrrset_controller.go
+++ b/internal/controller/clusterrrset_controller.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/internal/controller/clusterrrset_controller_test.go
+++ b/internal/controller/clusterrrset_controller_test.go
@@ -23,7 +23,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 )
 
 var _ = Describe("ClusterRRset Controller", func() {

--- a/internal/controller/clusterrrset_controller_test.go
+++ b/internal/controller/clusterrrset_controller_test.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/internal/controller/clusterzone_controller.go
+++ b/internal/controller/clusterzone_controller.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 )
 
 // ClusterZoneReconciler reconciles a ClusterZone object

--- a/internal/controller/clusterzone_controller.go
+++ b/internal/controller/clusterzone_controller.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/internal/controller/clusterzone_controller_test.go
+++ b/internal/controller/clusterzone_controller_test.go
@@ -25,7 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 )
 
 var _ = Describe("ClusterZone Controller", func() {

--- a/internal/controller/clusterzone_controller_test.go
+++ b/internal/controller/clusterzone_controller_test.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/joeig/go-powerdns/v3"
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/internal/controller/common_test.go
+++ b/internal/controller/common_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/joeig/go-powerdns/v3"
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )

--- a/internal/controller/common_test.go
+++ b/internal/controller/common_test.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/internal/controller/pdns_helper.go
+++ b/internal/controller/pdns_helper.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"github.com/joeig/go-powerdns/v3"
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 	"k8s.io/utils/ptr"
 )
 

--- a/internal/controller/pdns_helper.go
+++ b/internal/controller/pdns_helper.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/internal/controller/pdns_helper_test.go
+++ b/internal/controller/pdns_helper_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/joeig/go-powerdns/v3"
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )

--- a/internal/controller/pdns_helper_test.go
+++ b/internal/controller/pdns_helper_test.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/internal/controller/pdns_metrics.go
+++ b/internal/controller/pdns_metrics.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )

--- a/internal/controller/rrset_controller.go
+++ b/internal/controller/rrset_controller.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 )
 
 const (

--- a/internal/controller/rrset_controller.go
+++ b/internal/controller/rrset_controller.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/internal/controller/rrset_controller_test.go
+++ b/internal/controller/rrset_controller_test.go
@@ -24,7 +24,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 )
 
 var _ = Describe("RRset Controller", func() {

--- a/internal/controller/rrset_controller_test.go
+++ b/internal/controller/rrset_controller_test.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -40,7 +40,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/internal/controller/zone_controller.go
+++ b/internal/controller/zone_controller.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 )
 
 const (

--- a/internal/controller/zone_controller.go
+++ b/internal/controller/zone_controller.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/internal/controller/zone_controller_test.go
+++ b/internal/controller/zone_controller_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	dnsv1alpha2 "github.com/orange-opensource/powerdns-operator/api/v1alpha2"
+	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 )
 
 var _ = Describe("Zone Controller", func() {

--- a/internal/controller/zone_controller_test.go
+++ b/internal/controller/zone_controller_test.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,9 @@ site_description: >-
   Manage PowerDNS from a Kubernetes cluster simple Custom Resources.
 repo_url: https://github.com/powerdns-operator/PowerDNS-Operator
 repo_name: PowerDNS Operator
-copyright: Copyright (c) Orange Business Services SA
+copyright: |
+  Copyright (c) PowerDNS-Operator contributors
+  Copyright (c) 2025 Orange Business Services SA
 theme:
   name: material
   features:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: PowerDNS Operator
-site_url: https://orange-opensource.github.io/powerdns-operator/
+site_url: https://powerdns-operator.github.io/powerdns-operator/
 site_description: >-
   Manage PowerDNS from a Kubernetes cluster simple Custom Resources.
-repo_url: https://github.com/Orange-OpenSource/PowerDNS-Operator
+repo_url: https://github.com/powerdns-operator/PowerDNS-Operator
 repo_name: PowerDNS Operator
 copyright: Copyright (c) Orange Business Services SA
 theme:

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/orange-opensource/powerdns-operator/test/utils"
+	"github.com/powerdns-operator/powerdns-operator/test/utils"
 )
 
 const namespace = "powerdns-operator-system"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -1,7 +1,8 @@
 /*
  * Software Name : PowerDNS-Operator
  *
- * SPDX-FileCopyrightText: Copyright (c) Orange Business Services SA
+ * SPDX-FileCopyrightText: Copyright (c) PowerDNS-Operator contributors
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange Business Services SA
  * SPDX-License-Identifier: Apache-2.0
  *
  * This software is distributed under the Apache 2.0 License,


### PR DESCRIPTION
This PR aims to update all references related to the previous Orange-Opensource organization.

---

We would like to thank Orange Business for its kindness and for allowing us to continue maintaining the software as an open source project.
We are also grateful for their support in migrating the repositories to this new GitHub organization dedicated to the  PowerDNS-Operator.