### PR TITLE
fix: improve PowerDNS client initialization with proper error handling

### DIFF
--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -48,3 +48,14 @@ kubectl apply -f https://github.com/powerdns-operator/PowerDNS-Operator/releases
 ## Installing with Helm
 
 A Helm chart is available on a [specific project](https://github.com/powerdns-operator/PowerDNS-Operator-helm-chart).
+
+## Environment Variables
+
+The PowerDNS Operator can be configured using the following environment variables:
+
+| Environment Variable | Description | Default Value | Required |
+|---------------------|-------------|---------------|----------|
+| `PDNS_API_URL` | The URL of the PowerDNS API server | `http://localhost:8081` | Yes |
+| `PDNS_API_KEY` | The API key for authenticating with PowerDNS | `secret` | Yes |
+| `PDNS_API_VHOST` | The virtual host name for the PowerDNS API | `localhost` | Yes |
+| `PDNS_API_TIMEOUT` | Timeout in seconds for PowerDNS API requests | `10` | No |


### PR DESCRIPTION
- Fix incorrect error handling in PDNSClientInitializer function call
- Add connectivity test during client initialization using Servers.Get API
- Enhance operational visibility by logging PowerDNS server information
- Add validation warning for non-Authoritative server types
- Include 10-second timeout for connectivity test to prevent startup hangs

The previous code checked a stale error variable after PDNSClientInitializer call, which could lead to confusing behavior. Now the function properly returns an error and validates the connection at startup time.

Resolves startup reliability issues and improves operational experience.

```json
{"level":"info","ts":"2025-06-25T20:46:38+02:00","logger":"setup","msg":"PowerDNS API URL","url":"https://powerdns:8081"}
{"level":"info","ts":"2025-06-25T20:46:38+02:00","logger":"setup","msg":"PowerDNS API vhost","vhost":"localhost"}
{"level":"info","ts":"2025-06-25T20:46:40+02:00","logger":"setup","msg":"Connected to PowerDNS server","version":"4.9.2"}
{"level":"info","ts":"2025-06-25T20:46:40+02:00","logger":"setup","msg":"PowerDNS daemon type","type":"authoritative"}
{"level":"info","ts":"2025-06-25T20:46:40+02:00","logger":"setup","msg":"PowerDNS server ID","id":"localhost"}
{"level":"info","ts":"2025-06-25T20:46:40+02:00","logger":"setup","msg":"PowerDNS connectivity test successful","url":"https://powerdns:8081","vhost":"localhost"}
{"level":"info","ts":"2025-06-25T20:46:41+02:00","logger":"setup","msg":"starting manager"}
```