### PR TITLE
fix(config)!: remove default values for mandatory environment variables

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -59,22 +59,15 @@ func main() {
 	var secureMetrics bool
 	var enableHTTP2 bool
 
+	// Get environment variables for PowerDNS API configuration
 	apiURL := os.Getenv("PDNS_API_URL")
-	if apiURL == "" {
-		apiURL = "http://localhost:8081"
-	}
-
 	apiKey := os.Getenv("PDNS_API_KEY")
-	if apiKey == "" {
-		apiKey = "secret"
-	}
-
 	apiVhost := os.Getenv("PDNS_API_VHOST")
 	if apiVhost == "" {
 		apiVhost = "localhost"
 	}
 
-	// Parse API timeout from environment variable (in seconds)
+	// Parse PowerDNS API timeout from environment variable (in seconds)
 	apiTimeoutStr := os.Getenv("PDNS_API_TIMEOUT")
 	apiTimeoutSeconds := 10 // default timeout in seconds
 	if apiTimeoutStr != "" {
@@ -83,6 +76,7 @@ func main() {
 		}
 	}
 
+	// Parse command line flags
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
@@ -104,7 +98,18 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Validate mandatory configuration
+	if apiURL == "" {
+		setupLog.Error(nil, "PDNS_API_URL environment variable or --pdns-api-url flag is required")
+		os.Exit(1)
+	}
 	setupLog.Info("PowerDNS API URL", "url", apiURL)
+
+	if apiKey == "" {
+		setupLog.Error(nil, "PDNS_API_KEY environment variable or --pdns-api-key flag is required")
+		os.Exit(1)
+	}
 	setupLog.Info("PowerDNS API vhost", "vhost", apiVhost)
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -55,7 +55,9 @@ The PowerDNS Operator can be configured using the following environment variable
 
 | Environment Variable | Description | Default Value | Required |
 |---------------------|-------------|---------------|----------|
-| `PDNS_API_URL` | The URL of the PowerDNS API server | `http://localhost:8081` | Yes |
-| `PDNS_API_KEY` | The API key for authenticating with PowerDNS | `secret` | Yes |
-| `PDNS_API_VHOST` | The virtual host name for the PowerDNS API | `localhost` | Yes |
+| `PDNS_API_URL` | The URL of the PowerDNS API server | None | Yes |
+| `PDNS_API_KEY` | The API key for authenticating with PowerDNS | None | Yes |
+| `PDNS_API_VHOST` | The virtual host name for the PowerDNS API | `localhost` | No |
 | `PDNS_API_TIMEOUT` | Timeout in seconds for PowerDNS API requests | `10` | No |
+
+> **Important**: The operator will fail to start if any of the required environment variables is not provided.


### PR DESCRIPTION
- Remove default values for `PDNS_API_URL` and `PDNS_API_KEY`
- Make operator exit(1) with clear error messages when mandatory env var is missing
- Update documentation to reflect that these variables are required

This ensures the operator only start with valid configuration

with invalid config
> {"level":"error","ts":"2025-06-26T22:41:29+02:00","logger":"setup","msg":"PDNS_API_URL environment variable or --pdns-api-url flag is required","stacktrace":"<redacted>"}

with valid config
> {"level":"info","ts":"2025-06-26T22:42:40+02:00","logger":"setup","msg":"PowerDNS API URL","url":"https://powerdns:8081"}
{"level":"info","ts":"2025-06-26T22:42:40+02:00","logger":"setup","msg":"PowerDNS API vhost","vhost":"localhost"}
{"level":"info","ts":"2025-06-26T22:42:43+02:00","logger":"setup","msg":"Connected to PowerDNS server","version":"4.9.2"}