### PR TITLE
Feat/watch namespace env

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -30,6 +31,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -82,6 +84,13 @@ func main() {
 	}
 	apiCAPath := os.Getenv("PDNS_API_CA_PATH")
 
+	// Comma-separated list of namespaces the manager should watch. When empty
+	// (the default), the manager watches the whole cluster and all reconcilers
+	// (Zone, RRset, ClusterZone, ClusterRRset) are registered. When set, the
+	// cache is scoped to the listed namespaces for namespaced resources while
+	// cluster-scoped resources continue to be watched cluster-wide.
+	watchNamespace := os.Getenv("WATCH_NAMESPACE")
+
 	// Parse PowerDNS API timeout from environment variable (in seconds)
 	apiTimeoutStr := os.Getenv("PDNS_API_TIMEOUT")
 	apiTimeoutSeconds := 10 // default timeout in seconds
@@ -116,6 +125,12 @@ func main() {
 	flag.BoolVar(&apiInsecure, "pdns-api-insecure", apiInsecure,
 		"Enable insecure connections to PowerDNS API")
 	flag.StringVar(&apiCAPath, "pdns-api-ca-path", apiCAPath, "The path to certificate authority")
+	flag.StringVar(&watchNamespace, "watch-namespace", watchNamespace,
+		"Comma-separated list of namespaces to watch. "+
+			"If empty (the default), the manager watches all namespaces and "+
+			"all reconcilers are registered. When set, namespaced resources are "+
+			"scoped to the listed namespaces while cluster-scoped resources "+
+			"continue to be watched cluster-wide.")
 
 	opts := zap.Options{
 		Development: false,
@@ -208,7 +223,7 @@ func main() {
 		metricsServerOptions.KeyName = metricsCertKey
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgrOptions := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
@@ -226,7 +241,29 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
-	})
+	}
+
+	// Scope the manager's cache to a list of namespaces when WATCH_NAMESPACE is
+	// set. An empty value preserves the historical cluster-wide behaviour.
+	if watchNamespace != "" {
+		namespaces := map[string]cache.Config{}
+		for _, ns := range strings.Split(watchNamespace, ",") {
+			ns = strings.TrimSpace(ns)
+			if ns != "" {
+				namespaces[ns] = cache.Config{}
+			}
+		}
+		if len(namespaces) == 0 {
+			setupLog.Error(nil, "WATCH_NAMESPACE was set but contained no valid namespace names")
+			os.Exit(1)
+		}
+		mgrOptions.Cache = cache.Options{DefaultNamespaces: namespaces}
+		setupLog.Info("manager scoped to namespaces", "namespaces", watchNamespace)
+	} else {
+		setupLog.Info("manager watching all namespaces (cluster-wide)")
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/docs/introduction/getting-started.md
+++ b/docs/introduction/getting-started.md
@@ -68,6 +68,7 @@ kubectl apply -f https://github.com/powerdns-operator/PowerDNS-Operator/releases
 | `PDNS_API_TIMEOUT` | PowerDNS API request timeout in seconds | No | `10` |
 | `PDNS_API_INSECURE` | Insecure connections with PowerDNS API | No | "False" |
 | `PDNS_API_CA_PATH` | Path to Certificate Authority | No | None |
+| `WATCH_NAMESPACE` | Comma-separated list of namespaces to watch. When empty, the manager watches `Zone` and `RRset` resources cluster-wide. When set, the cache is scoped to the listed namespaces so the operator only reconciles `Zone` and `RRset` CRs in those namespaces. Cluster-scoped CRDs (`ClusterZone`, `ClusterRRset`) are always reconciled cluster-wide regardless of this setting. | No | None |
 
 ### Verification
 


### PR DESCRIPTION
Closes #307

Adds a `WATCH_NAMESPACE` environment variable (also exposed as
`--watch-namespace`) that scopes the manager's cache for the namespaced
`Zone` and `RRset` reconcilers to one or more namespaces. The
cluster-scoped `ClusterZone` / `ClusterRRset` reconcilers continue to
watch cluster-wide.

When unset, behaviour is unchanged.