### PR TITLE
fix: Failed RRset for wrong type are never deleted

### DIFF
--- a/api/v1alpha2/clusterrrset_types.go
+++ b/api/v1alpha2/clusterrrset_types.go
@@ -12,6 +12,7 @@
 package v1alpha2
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -48,9 +49,16 @@ func init() {
 }
 
 // IsInExpectedStatus returns true if Status.SyncStatus and Status.ObservedGeneration are, at least, at expected value
-func (r *ClusterRRset) IsInExpectedStatus(expectedMinimumObservedGeneration int64, expectedSyncStatus string) bool {
+func (r *ClusterRRset) IsInExpectedStatus(
+	expectedMinimumObservedGeneration int64,
+	expectedSyncStatus string,
+	expectedConditionStatus metav1.ConditionStatus,
+) bool {
+	currentAvailableCondition := meta.FindStatusCondition(r.Status.Conditions, "Available")
 	return r.Status.ObservedGeneration != nil &&
 		*r.Status.ObservedGeneration >= expectedMinimumObservedGeneration &&
 		r.Status.SyncStatus != nil &&
-		*r.Status.SyncStatus == expectedSyncStatus
+		*r.Status.SyncStatus == expectedSyncStatus &&
+		currentAvailableCondition != nil &&
+		currentAvailableCondition.Status == expectedConditionStatus
 }

--- a/api/v1alpha2/clusterzone_types.go
+++ b/api/v1alpha2/clusterzone_types.go
@@ -12,6 +12,7 @@
 package v1alpha2
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -45,9 +46,16 @@ func init() {
 }
 
 // IsInExpectedStatus returns true if Status.SyncStatus and Status.ObservedGeneration are, at least, at expected value
-func (z *ClusterZone) IsInExpectedStatus(expectedMinimumObservedGeneration int64, expectedSyncStatus string) bool {
+func (z *ClusterZone) IsInExpectedStatus(
+	expectedMinimumObservedGeneration int64,
+	expectedSyncStatus string,
+	expectedConditionStatus metav1.ConditionStatus,
+) bool {
+	currentAvailableCondition := meta.FindStatusCondition(z.Status.Conditions, "Available")
 	return z.Status.ObservedGeneration != nil &&
 		*z.Status.ObservedGeneration >= expectedMinimumObservedGeneration &&
 		z.Status.SyncStatus != nil &&
-		*z.Status.SyncStatus == expectedSyncStatus
+		*z.Status.SyncStatus == expectedSyncStatus &&
+		currentAvailableCondition != nil &&
+		currentAvailableCondition.Status == expectedConditionStatus
 }

--- a/api/v1alpha2/constants.go
+++ b/api/v1alpha2/constants.go
@@ -1,0 +1,7 @@
+package v1alpha2
+
+const (
+	FAILED_STATUS    = "Failed"
+	PENDING_STATUS   = "Pending"
+	SUCCEEDED_STATUS = "Succeeded"
+)

--- a/api/v1alpha2/constants.go
+++ b/api/v1alpha2/constants.go
@@ -1,7 +1,8 @@
 package v1alpha2
 
 const (
-	FAILED_STATUS    = "Failed"
-	PENDING_STATUS   = "Pending"
-	SUCCEEDED_STATUS = "Succeeded"
+	FAILED_STATUS        = "Failed"
+	PENDING_STATUS       = "Pending"
+	SUCCEEDED_STATUS     = "Succeeded"
+	UNPROCESSABLE_STATUS = "Unprocessable"
 )

--- a/api/v1alpha2/rrset_types.go
+++ b/api/v1alpha2/rrset_types.go
@@ -12,6 +12,7 @@
 package v1alpha2
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -85,9 +86,16 @@ func init() {
 }
 
 // IsInExpectedStatus returns true if Status.SyncStatus and Status.ObservedGeneration are, at least, at expected value
-func (r *RRset) IsInExpectedStatus(expectedMinimumObservedGeneration int64, expectedSyncStatus string) bool {
+func (r *RRset) IsInExpectedStatus(
+	expectedMinimumObservedGeneration int64,
+	expectedSyncStatus string,
+	expectedConditionStatus metav1.ConditionStatus,
+) bool {
+	currentAvailableCondition := meta.FindStatusCondition(r.Status.Conditions, "Available")
 	return r.Status.ObservedGeneration != nil &&
 		*r.Status.ObservedGeneration >= expectedMinimumObservedGeneration &&
 		r.Status.SyncStatus != nil &&
-		*r.Status.SyncStatus == expectedSyncStatus
+		*r.Status.SyncStatus == expectedSyncStatus &&
+		currentAvailableCondition != nil &&
+		currentAvailableCondition.Status == expectedConditionStatus
 }

--- a/api/v1alpha2/zone_types.go
+++ b/api/v1alpha2/zone_types.go
@@ -12,6 +12,7 @@
 package v1alpha2
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -99,9 +100,16 @@ func init() {
 }
 
 // IsInExpectedStatus returns true if Status.SyncStatus and Status.ObservedGeneration are, at least, at expected value
-func (z *Zone) IsInExpectedStatus(expectedMinimumObservedGeneration int64, expectedSyncStatus string) bool {
+func (z *Zone) IsInExpectedStatus(
+	expectedMinimumObservedGeneration int64,
+	expectedSyncStatus string,
+	expectedConditionStatus metav1.ConditionStatus,
+) bool {
+	currentAvailableCondition := meta.FindStatusCondition(z.Status.Conditions, "Available")
 	return z.Status.ObservedGeneration != nil &&
 		*z.Status.ObservedGeneration >= expectedMinimumObservedGeneration &&
 		z.Status.SyncStatus != nil &&
-		*z.Status.SyncStatus == expectedSyncStatus
+		*z.Status.SyncStatus == expectedSyncStatus &&
+		currentAvailableCondition != nil &&
+		currentAvailableCondition.Status == expectedConditionStatus
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+	"go.uber.org/zap/zapcore"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -111,7 +112,10 @@ func main() {
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctrl.SetLogger(zap.New(
+		zap.UseFlagOptions(&opts),
+		zap.StacktraceLevel(zapcore.PanicLevel), // Only stacktrace at panic level
+	))
 
 	// Validate mandatory configuration
 	if apiURL == "" {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/prometheus/client_golang v1.23.2
+	go.uber.org/zap v1.27.0
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2
@@ -48,7 +49,6 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.32.0 // indirect

--- a/internal/controller/clusterrrset_controller.go
+++ b/internal/controller/clusterrrset_controller.go
@@ -15,7 +15,7 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -102,7 +102,7 @@ func (r *ClusterRRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	err = r.Get(ctx, client.ObjectKey{Namespace: rrset.Namespace, Name: rrset.Spec.ZoneRef.Name}, zone)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Zone not found, remove finalizer and requeue
 			actionOnFinalizer := false
 			if controllerutil.ContainsFinalizer(rrset, RESOURCES_FINALIZER_NAME) {

--- a/internal/controller/clusterrrset_controller.go
+++ b/internal/controller/clusterrrset_controller.go
@@ -125,7 +125,7 @@ func (r *ClusterRRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			// If RRset is under deletion, no need to update its status
 			if !isDeleted {
 				original = rrset.DeepCopy()
-				rrset.Status.SyncStatus = ptr.To(PENDING_STATUS)
+				rrset.Status.SyncStatus = ptr.To(dnsv1alpha2.PENDING_STATUS)
 				rrset.Status.ObservedGeneration = &rrset.Generation
 				meta.SetStatusCondition(&rrset.Status.Conditions, metav1.Condition{
 					Type:               "Available",
@@ -151,10 +151,10 @@ func (r *ClusterRRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 	// If a Zone/ClusterZone exists but is in Failed Status
-	zoneIsInFailedStatus := (zone.GetStatus().SyncStatus != nil && *zone.GetStatus().SyncStatus == FAILED_STATUS)
+	zoneIsInFailedStatus := (zone.GetStatus().SyncStatus != nil && *zone.GetStatus().SyncStatus == dnsv1alpha2.FAILED_STATUS)
 	if zoneIsInFailedStatus {
 		original = rrset.DeepCopy()
-		rrset.Status.SyncStatus = ptr.To(FAILED_STATUS)
+		rrset.Status.SyncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
 		rrset.Status.ObservedGeneration = &rrset.Generation
 		meta.SetStatusCondition(&rrset.Status.Conditions, metav1.Condition{
 			Type:               "Available",
@@ -195,7 +195,7 @@ func (r *ClusterRRsetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &dnsv1alpha2.ClusterRRset{}, "ClusterRRset.Entry.Name", func(rawObj client.Object) []string {
 		// grab the ClusterRRset object, extract its name...
 		var RRsetName string
-		if rawObj.(*dnsv1alpha2.ClusterRRset).Status.SyncStatus == nil || *rawObj.(*dnsv1alpha2.ClusterRRset).Status.SyncStatus == SUCCEEDED_STATUS {
+		if rawObj.(*dnsv1alpha2.ClusterRRset).Status.SyncStatus == nil || *rawObj.(*dnsv1alpha2.ClusterRRset).Status.SyncStatus == dnsv1alpha2.SUCCEEDED_STATUS {
 			RRsetName = getRRsetName(rawObj.(*dnsv1alpha2.ClusterRRset)) + "/" + rawObj.(*dnsv1alpha2.ClusterRRset).Spec.Type
 		}
 		return []string{RRsetName}

--- a/internal/controller/clusterrrset_controller_test.go
+++ b/internal/controller/clusterrrset_controller_test.go
@@ -18,7 +18,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -146,7 +146,7 @@ var _ = Describe("ClusterRRset Controller", func() {
 		By("Verifying the resource has been deleted")
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, clusterRrsetLookupKey, resource)
-			return errors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}, timeout, interval).Should(BeTrue())
 
 		By("Cleaning up the specific resource instance Zone")
@@ -158,7 +158,7 @@ var _ = Describe("ClusterRRset Controller", func() {
 		By("Verifying the resource has been deleted")
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, clusterZoneLookupKey, zone)
-			return errors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}, timeout, interval).Should(BeTrue())
 		// Confirm that resource is deleted in the backend
 		Eventually(func() bool {

--- a/internal/controller/clusterrrset_controller_test.go
+++ b/internal/controller/clusterrrset_controller_test.go
@@ -175,7 +175,7 @@ var _ = Describe("ClusterRRset Controller", func() {
 			createdResource := &dnsv1alpha2.ClusterRRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, clusterRrsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countClusterRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")
@@ -236,7 +236,7 @@ var _ = Describe("ClusterRRset Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, recreatedRrset)
-				return err == nil && recreatedRrset.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS)
+				return err == nil && recreatedRrset.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/internal/controller/clusterrrset_controller_test.go
+++ b/internal/controller/clusterrrset_controller_test.go
@@ -175,11 +175,11 @@ var _ = Describe("ClusterRRset Controller", func() {
 			createdResource := &dnsv1alpha2.ClusterRRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, clusterRrsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countClusterRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")
-			Expect(getClusterRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, SUCCEEDED_STATUS, resourceName)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getClusterRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, dnsv1alpha2.SUCCEEDED_STATUS, resourceName)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(resourceName, resourceType)).To(Equal(resourceRecords))
 			Expect(getMockedTTL(resourceName, resourceType)).To(Equal(resourceTTL))
 			Expect(getMockedComment(resourceName, resourceType)).To(Equal(resourceComment))
@@ -236,7 +236,7 @@ var _ = Describe("ClusterRRset Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, recreatedRrset)
-				return err == nil && recreatedRrset.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
+				return err == nil && recreatedRrset.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/internal/controller/clusterzone_controller.go
+++ b/internal/controller/clusterzone_controller.go
@@ -90,7 +90,7 @@ func (r *ClusterZoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &dnsv1alpha2.ClusterZone{}, "ClusterZone.Entry.Name", func(rawObj client.Object) []string {
 		// grab the ClusterZone object, extract its name...
 		var ZoneName string
-		if rawObj.(*dnsv1alpha2.ClusterZone).Status.SyncStatus == nil || *rawObj.(*dnsv1alpha2.ClusterZone).Status.SyncStatus == SUCCEEDED_STATUS {
+		if rawObj.(*dnsv1alpha2.ClusterZone).Status.SyncStatus == nil || *rawObj.(*dnsv1alpha2.ClusterZone).Status.SyncStatus == dnsv1alpha2.SUCCEEDED_STATUS {
 			ZoneName = (rawObj.(*dnsv1alpha2.ClusterZone)).Name
 		}
 		return []string{ZoneName}

--- a/internal/controller/clusterzone_controller_test.go
+++ b/internal/controller/clusterzone_controller_test.go
@@ -107,10 +107,10 @@ var _ = Describe("ClusterZone Controller", func() {
 			clusterzone := &dnsv1alpha2.ClusterZone{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, clusterzone)
-				return err == nil && clusterzone.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && clusterzone.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			Expect(countClusterZonesMetrics()-ic).To(Equal(0), "No more metric should have been created")
-			Expect(getClusterZoneMetricWithLabels(SUCCEEDED_STATUS, resourceName)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getClusterZoneMetricWithLabels(dnsv1alpha2.SUCCEEDED_STATUS, resourceName)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedKind(resourceName)).To(Equal(resourceKind), "Kind should be equal")
 			Expect(getMockedNameservers(resourceName)).To(Equal(resourceNameservers), "Nameservers should be equal")
 			Expect(getMockedCatalog(resourceName)).To(Equal(resourceCatalog), "Catalog should be equal")
@@ -155,7 +155,7 @@ var _ = Describe("ClusterZone Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, updatedZone)
-				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
+				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/internal/controller/clusterzone_controller_test.go
+++ b/internal/controller/clusterzone_controller_test.go
@@ -19,7 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -90,7 +90,7 @@ var _ = Describe("ClusterZone Controller", func() {
 		// Waiting for the resource to be fully deleted
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			return errors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}, timeout, interval).Should(BeTrue())
 		// Confirm that resource is deleted in the backend
 		Eventually(func() bool {

--- a/internal/controller/clusterzone_controller_test.go
+++ b/internal/controller/clusterzone_controller_test.go
@@ -107,7 +107,7 @@ var _ = Describe("ClusterZone Controller", func() {
 			clusterzone := &dnsv1alpha2.ClusterZone{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, clusterzone)
-				return err == nil && clusterzone.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && clusterzone.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			Expect(countClusterZonesMetrics()-ic).To(Equal(0), "No more metric should have been created")
 			Expect(getClusterZoneMetricWithLabels(SUCCEEDED_STATUS, resourceName)).To(Equal(1.0), "metric should be 1.0")
@@ -155,7 +155,7 @@ var _ = Describe("ClusterZone Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, updatedZone)
-				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS)
+				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -13,6 +13,8 @@ package controller
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -28,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
+
+var ErrUnprocessableError = errors.New("Unprocessable")
 
 func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified bool, isDeleted bool, cl client.Client, PDNSClient PdnsClienter, log logr.Logger) (ctrl.Result, error) {
 	isInFailedStatus := (gz.GetStatus().SyncStatus != nil && *gz.GetStatus().SyncStatus == dnsv1alpha2.FAILED_STATUS)
@@ -169,6 +173,7 @@ func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified b
 
 func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1alpha2.GenericZone, isModified bool, isDeleted bool, lastUpdateTime *metav1.Time, scheme *runtime.Scheme, cl client.Client, PDNSClient PdnsClienter, log logr.Logger) (ctrl.Result, error) {
 	isInFailedStatus := (gr.GetStatus().SyncStatus != nil && *gr.GetStatus().SyncStatus == dnsv1alpha2.FAILED_STATUS)
+	isUnprocessable := gr.GetStatus().SyncStatus != nil && *gr.GetStatus().SyncStatus == dnsv1alpha2.UNPROCESSABLE_STATUS
 
 	// initialize syncStatus
 	var syncStatus *string
@@ -181,12 +186,15 @@ func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object. This is equivalent
 		// to registering our finalizer.
-		if !controllerutil.ContainsFinalizer(gr, RESOURCES_FINALIZER_NAME) {
-			controllerutil.AddFinalizer(gr, RESOURCES_FINALIZER_NAME)
-			lastUpdateTime = &metav1.Time{Time: time.Now().UTC()}
-			if err := cl.Update(ctx, gr); err != nil {
-				log.Error(err, "Failed to add finalizer")
-				return ctrl.Result{}, err
+		// Except for Unprocessable status: we don't want to add the finalizer
+		if !isUnprocessable {
+			if !controllerutil.ContainsFinalizer(gr, RESOURCES_FINALIZER_NAME) {
+				controllerutil.AddFinalizer(gr, RESOURCES_FINALIZER_NAME)
+				lastUpdateTime = &metav1.Time{Time: time.Now().UTC()}
+				if err := cl.Update(ctx, gr); err != nil {
+					log.Error(err, "Failed to add finalizer")
+					return ctrl.Result{}, err
+				}
 			}
 		}
 	} else {
@@ -224,7 +232,7 @@ func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1
 	}
 
 	// We cannot exit previously (at the early moments of reconcile), because we have to allow deletion process
-	if isInFailedStatus && !isModified {
+	if (isInFailedStatus || isUnprocessable) && !isModified {
 		// Update resource metrics
 		updateRrsetsMetrics(getRRsetName(gr), gr)
 		return ctrl.Result{}, nil
@@ -279,13 +287,29 @@ func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1
 	}
 
 	// Create or Update
-	changed, err := createOrUpdateRrsetExternalResources(ctx, zone, gr, PDNSClient)
-	if err != nil {
-		log.Error(err, "Failed to create or update external resources")
-		syncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
-		conditionStatus = metav1.ConditionFalse
-		conditionReason = RrsetReasonSynchronizationFailed
-		conditionMessage = err.Error()
+	var changed bool
+	var err error
+	if !isUnprocessable {
+		changed, err = createOrUpdateRrsetExternalResources(ctx, zone, gr, PDNSClient)
+		if err != nil {
+			log.Error(err, "Failed to create or update external resources")
+			if errors.Is(err, ErrUnprocessableError) {
+				syncStatus = ptr.To(dnsv1alpha2.UNPROCESSABLE_STATUS)
+				conditionStatus = metav1.ConditionFalse
+				conditionReason = RrsetReasonUnprocessable
+				conditionMessage = err.Error()
+				controllerutil.RemoveFinalizer(gr, RESOURCES_FINALIZER_NAME)
+				if err := cl.Update(ctx, gr); err != nil {
+					log.Error(err, "Failed to remove finalizer")
+					return ctrl.Result{}, err
+				}
+			} else {
+				syncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
+				conditionStatus = metav1.ConditionFalse
+				conditionReason = RrsetReasonSynchronizationFailed
+				conditionMessage = err.Error()
+			}
+		}
 	}
 	if changed {
 		lastUpdateTime = &metav1.Time{Time: time.Now().UTC()}
@@ -560,6 +584,14 @@ func createOrUpdateRrsetExternalResources(ctx context.Context, zone dnsv1alpha2.
 	}
 	err = PDNSClient.Records.Change(ctx, zone.GetObjectMeta().Name, name, rrType, rrset.GetSpec().TTL, rrset.GetSpec().Records, comments)
 	if err != nil {
+		// Identify if the error is a 422 Unprocessable Entity
+		var pdnsError *powerdns.Error
+		if errors.As(err, &pdnsError) {
+			if pdnsError.StatusCode == 422 && pdnsError.Status == "422 Unprocessable Entity" {
+				return false, fmt.Errorf("%w: %w", ErrUnprocessableError, err)
+			}
+		}
+
 		return false, err
 	}
 

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -115,7 +115,7 @@ func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified b
 			Conditions:         conditions,
 		})
 		if err := cl.Status().Patch(ctx, gz, client.MergeFrom(original)); err != nil {
-			log.Error(err, "unable to patch RRSet status")
+			log.Error(err, "unable to patch ClusterZone/Zone status")
 			return ctrl.Result{}, err
 		}
 

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -30,7 +30,7 @@ import (
 )
 
 func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified bool, isDeleted bool, cl client.Client, PDNSClient PdnsClienter, log logr.Logger) (ctrl.Result, error) {
-	isInFailedStatus := (gz.GetStatus().SyncStatus != nil && *gz.GetStatus().SyncStatus == FAILED_STATUS)
+	isInFailedStatus := (gz.GetStatus().SyncStatus != nil && *gz.GetStatus().SyncStatus == dnsv1alpha2.FAILED_STATUS)
 
 	// examine DeletionTimestamp to determine if object is under deletion
 	if !isDeleted {
@@ -110,7 +110,7 @@ func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified b
 			Message:            ZoneMessageDuplicated,
 		})
 		gz.SetStatus(dnsv1alpha2.ZoneStatus{
-			SyncStatus:         ptr.To(FAILED_STATUS),
+			SyncStatus:         ptr.To(dnsv1alpha2.FAILED_STATUS),
 			ObservedGeneration: &gz.GetObjectMeta().Generation,
 			Conditions:         conditions,
 		})
@@ -137,7 +137,7 @@ func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified b
 	}
 
 	if syncStatus == nil {
-		syncStatus = ptr.To(SUCCEEDED_STATUS)
+		syncStatus = ptr.To(dnsv1alpha2.SUCCEEDED_STATUS)
 	}
 
 	// Update ZoneStatus
@@ -168,7 +168,7 @@ func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified b
 }
 
 func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1alpha2.GenericZone, isModified bool, isDeleted bool, lastUpdateTime *metav1.Time, scheme *runtime.Scheme, cl client.Client, PDNSClient PdnsClienter, log logr.Logger) (ctrl.Result, error) {
-	isInFailedStatus := (gr.GetStatus().SyncStatus != nil && *gr.GetStatus().SyncStatus == FAILED_STATUS)
+	isInFailedStatus := (gr.GetStatus().SyncStatus != nil && *gr.GetStatus().SyncStatus == dnsv1alpha2.FAILED_STATUS)
 
 	// initialize syncStatus
 	var syncStatus *string
@@ -263,7 +263,7 @@ func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1
 		gr.SetStatus(dnsv1alpha2.RRsetStatus{
 			LastUpdateTime:     lastUpdateTime,
 			DnsEntryName:       &name,
-			SyncStatus:         ptr.To(FAILED_STATUS),
+			SyncStatus:         ptr.To(dnsv1alpha2.FAILED_STATUS),
 			ObservedGeneration: &gr.GetObjectMeta().Generation,
 			Conditions:         conditions,
 		})
@@ -282,7 +282,7 @@ func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1
 	changed, err := createOrUpdateRrsetExternalResources(ctx, zone, gr, PDNSClient)
 	if err != nil {
 		log.Error(err, "Failed to create or update external resources")
-		syncStatus = ptr.To(FAILED_STATUS)
+		syncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
 		conditionStatus = metav1.ConditionFalse
 		conditionReason = RrsetReasonSynchronizationFailed
 		conditionMessage = err.Error()
@@ -308,7 +308,7 @@ func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1
 	// This update permits triggering a new event after RRSet update applied
 	original := gr.Copy()
 	if syncStatus == nil {
-		syncStatus = ptr.To(SUCCEEDED_STATUS)
+		syncStatus = ptr.To(dnsv1alpha2.SUCCEEDED_STATUS)
 	}
 	conditions := gr.GetStatus().Conditions
 	meta.SetStatusCondition(&conditions, metav1.Condition{
@@ -438,7 +438,7 @@ func zoneExternalResourcesReconcile(ctx context.Context, zoneRes *powerdns.Zone,
 		err := createZoneExternalResources(ctx, gz, PDNSClient, log)
 		if err != nil {
 			log.Error(err, "Failed to create external resources")
-			syncStatus = ptr.To(FAILED_STATUS)
+			syncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
 			conditionStatus = metav1.ConditionFalse
 			conditionReason = ZoneReasonSynchronizationFailed
 			conditionMessage = err.Error()
@@ -477,7 +477,7 @@ func zoneExternalResourcesReconcile(ctx context.Context, zoneRes *powerdns.Zone,
 			}
 			err := updateNsOnZoneExternalResources(ctx, gz, *ttl, PDNSClient, log)
 			if err != nil {
-				syncStatus = ptr.To(FAILED_STATUS)
+				syncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
 				conditionStatus = metav1.ConditionFalse
 				conditionReason = ZoneReasonNSSynchronizationFailed
 				conditionMessage = err.Error()
@@ -487,7 +487,7 @@ func zoneExternalResourcesReconcile(ctx context.Context, zoneRes *powerdns.Zone,
 		if !zoneIdentical {
 			err := updateZoneExternalResources(ctx, gz, PDNSClient, log)
 			if err != nil {
-				syncStatus = ptr.To(FAILED_STATUS)
+				syncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
 				conditionStatus = metav1.ConditionFalse
 				conditionReason = ZoneReasonSynchronizationFailed
 				conditionMessage = err.Error()

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -324,6 +324,7 @@ func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1
 		DnsEntryName:       &name,
 		SyncStatus:         syncStatus,
 		ObservedGeneration: &gr.GetObjectMeta().Generation,
+		Conditions:         conditions,
 	})
 	if err := cl.Status().Patch(ctx, gr, client.MergeFrom(original)); err != nil {
 		log.Error(err, "unable to patch RRSet status")

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -19,7 +19,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/joeig/go-powerdns/v3"
 	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -154,7 +154,7 @@ func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified b
 		Message:            conditionMessage,
 	})
 	if err != nil {
-		if errors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			log.Info("Object has been modified, forcing a new reconciliation")
 			return ctrl.Result{Requeue: true}, nil
 		}
@@ -293,7 +293,7 @@ func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1
 
 	// Set OwnerReference
 	if err := ownObject(ctx, zone, gr, scheme, cl, log); err != nil {
-		if errors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			log.Info("Conflict on RRSet owner reference, retrying")
 			return ctrl.Result{Requeue: true}, nil
 		}
@@ -535,7 +535,7 @@ func createOrUpdateRrsetExternalResources(ctx context.Context, zone dnsv1alpha2.
 	rrType := powerdns.RRType(rrset.GetSpec().Type)
 	// Looking for a record with same Name and Type
 	records, err := PDNSClient.Records.Get(ctx, zone.GetObjectMeta().Name, name, &rrType)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return false, err
 	}
 	// An issue exist on GET API Calls, comments for another RRSet are included although we filter

--- a/internal/controller/pdns_helper.go
+++ b/internal/controller/pdns_helper.go
@@ -22,12 +22,6 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-const (
-	FAILED_STATUS    = "Failed"
-	PENDING_STATUS   = "Pending"
-	SUCCEEDED_STATUS = "Succeeded"
-)
-
 type pdnsRecordsClienter interface {
 	Delete(ctx context.Context, domain string, name string, recordType powerdns.RRType) error
 	Change(ctx context.Context, domain string, name string, recordType powerdns.RRType, ttl uint32, content []string, options ...func(*powerdns.RRset)) error

--- a/internal/controller/rrset_controller.go
+++ b/internal/controller/rrset_controller.go
@@ -34,6 +34,7 @@ import (
 const (
 	RrsetReasonZoneNotAvailable      = "ZoneNotAvailable"
 	RrsetReasonSynchronizationFailed = "SynchronizationFailed"
+	RrsetReasonUnprocessable         = "Unprocessable"
 	RrsetReasonDuplicated            = "RrsetDuplicated"
 	RrsetReasonSynced                = "RrsetSynced"
 	RrsetMessageDuplicated           = "Already existing RRset with the same FQDN"

--- a/internal/controller/rrset_controller.go
+++ b/internal/controller/rrset_controller.go
@@ -138,7 +138,7 @@ func (r *RRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			// If RRset is under deletion, no need to update its status
 			if !isDeleted {
 				original = rrset.DeepCopy()
-				rrset.Status.SyncStatus = ptr.To(PENDING_STATUS)
+				rrset.Status.SyncStatus = ptr.To(dnsv1alpha2.PENDING_STATUS)
 				rrset.Status.ObservedGeneration = &rrset.Generation
 				meta.SetStatusCondition(&rrset.Status.Conditions, metav1.Condition{
 					Type:               "Available",
@@ -164,10 +164,10 @@ func (r *RRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 	}
 	// If a Zone/ClusterZone exists but is in Failed Status
-	zoneIsInFailedStatus := (zone.GetStatus().SyncStatus != nil && *zone.GetStatus().SyncStatus == FAILED_STATUS)
+	zoneIsInFailedStatus := (zone.GetStatus().SyncStatus != nil && *zone.GetStatus().SyncStatus == dnsv1alpha2.FAILED_STATUS)
 	if zoneIsInFailedStatus {
 		original = rrset.DeepCopy()
-		rrset.Status.SyncStatus = ptr.To(FAILED_STATUS)
+		rrset.Status.SyncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
 		rrset.Status.ObservedGeneration = &rrset.Generation
 		meta.SetStatusCondition(&rrset.Status.Conditions, metav1.Condition{
 			Type:               "Available",
@@ -208,7 +208,7 @@ func (r *RRsetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &dnsv1alpha2.RRset{}, "RRset.Entry.Name", func(rawObj client.Object) []string {
 		// grab the RRset object, extract its name...
 		var RRsetName string
-		if rawObj.(*dnsv1alpha2.RRset).Status.SyncStatus == nil || *rawObj.(*dnsv1alpha2.RRset).Status.SyncStatus == SUCCEEDED_STATUS {
+		if rawObj.(*dnsv1alpha2.RRset).Status.SyncStatus == nil || *rawObj.(*dnsv1alpha2.RRset).Status.SyncStatus == dnsv1alpha2.SUCCEEDED_STATUS {
 			RRsetName = getRRsetName(rawObj.(*dnsv1alpha2.RRset)) + "/" + rawObj.(*dnsv1alpha2.RRset).Spec.Type
 		}
 		return []string{RRsetName}

--- a/internal/controller/rrset_controller.go
+++ b/internal/controller/rrset_controller.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -115,7 +115,7 @@ func (r *RRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 	err = r.Get(ctx, client.ObjectKey{Namespace: rrset.Namespace, Name: rrset.Spec.ZoneRef.Name}, zone)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Zone not found, remove finalizer and requeue
 			actionOnFinalizer := false
 			if controllerutil.ContainsFinalizer(rrset, RESOURCES_FINALIZER_NAME) {

--- a/internal/controller/rrset_controller_test.go
+++ b/internal/controller/rrset_controller_test.go
@@ -181,7 +181,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, rssetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")
@@ -227,7 +227,7 @@ var _ = Describe("RRset Controller", func() {
 			updatedRRset := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, rssetLookupKey, updatedRRset)
-				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			Expect(countRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")
 			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
@@ -280,7 +280,7 @@ var _ = Describe("RRset Controller", func() {
 			updatedRRset := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, rssetLookupKey, updatedRRset)
-				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			Expect(countRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")
 			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
@@ -331,7 +331,7 @@ var _ = Describe("RRset Controller", func() {
 			updatedRRset := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, rssetLookupKey, updatedRRset)
-				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			Expect(countRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")
 			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
@@ -410,7 +410,7 @@ var _ = Describe("RRset Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, updatedRRset)
-				return err == nil && updatedRRset.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && updatedRRset.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -480,7 +480,7 @@ var _ = Describe("RRset Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, updatedRRset)
-				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")
@@ -609,7 +609,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -677,7 +677,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -744,7 +744,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -810,7 +810,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -877,7 +877,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -944,7 +944,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -1011,7 +1011,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -1111,7 +1111,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -1175,7 +1175,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, badTypeRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -1238,7 +1238,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, badFormatRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -1301,7 +1301,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, unquotedRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -1364,7 +1364,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, existingRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -1426,7 +1426,7 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, pendingRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, PENDING_STATUS)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, PENDING_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
@@ -1550,7 +1550,7 @@ var _ = Describe("RRset Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, recreatedZone)
-				return err == nil && recreatedZone.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS)
+				return err == nil && recreatedZone.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/internal/controller/rrset_controller_test.go
+++ b/internal/controller/rrset_controller_test.go
@@ -181,11 +181,11 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, rssetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")
-			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, dnsv1alpha2.SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(resourceName, resourceType)).To(Equal(resourceRecords))
 			Expect(getMockedTTL(resourceName, resourceType)).To(Equal(resourceTTL))
 			Expect(getMockedComment(resourceName, resourceType)).To(Equal(resourceComment))
@@ -227,10 +227,10 @@ var _ = Describe("RRset Controller", func() {
 			updatedRRset := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, rssetLookupKey, updatedRRset)
-				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			Expect(countRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")
-			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, dnsv1alpha2.SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(resourceName, resourceType)).To(Equal(updatedRecords))
 			Expect(getMockedTTL(resourceName, resourceType)).To(Equal(resourceTTL))
 			Expect(getMockedComment(resourceName, resourceType)).To(Equal(resourceComment))
@@ -280,10 +280,10 @@ var _ = Describe("RRset Controller", func() {
 			updatedRRset := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, rssetLookupKey, updatedRRset)
-				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			Expect(countRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")
-			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, dnsv1alpha2.SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(resourceName, resourceType)).To(Equal(resourceRecords))
 			Expect(getMockedTTL(resourceName, resourceType)).To(Equal(modifiedResourceTTL))
 			Expect(getMockedComment(resourceName, resourceType)).To(Equal(resourceComment))
@@ -331,10 +331,10 @@ var _ = Describe("RRset Controller", func() {
 			updatedRRset := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, rssetLookupKey, updatedRRset)
-				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			Expect(countRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")
-			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, dnsv1alpha2.SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(resourceName, resourceType)).To(Equal(resourceRecords))
 			Expect(getMockedTTL(resourceName, resourceType)).To(Equal(resourceTTL))
 			Expect(getMockedComment(resourceName, resourceType)).To(Equal(modifiedResourceComment))
@@ -410,11 +410,11 @@ var _ = Describe("RRset Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, updatedRRset)
-				return err == nil && updatedRRset.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && updatedRRset.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, dnsv1alpha2.SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Eventually(func() bool {
 				return getMockedRecordsForType(recreationResourceName, recreationResourceType) != nil
 			}, timeout, interval).Should(BeTrue())
@@ -480,11 +480,11 @@ var _ = Describe("RRset Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, updatedRRset)
-				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && updatedRRset.IsInExpectedStatus(MODIFIED_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")
-			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(resourceDNSName+"."+zoneRef+".", resourceType, dnsv1alpha2.SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(resourceName, resourceType)).To(Equal(modifiedResourceRecords))
 			Expect(getMockedTTL(resourceName, resourceType)).To(Equal(modifiedResourceTTL))
 			Expect(getMockedComment(resourceName, resourceType)).To(Equal(modifiedResourceComment))
@@ -609,11 +609,11 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, dnsv1alpha2.SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceRecords))
 			Expect(getMockedTTL(DnsFqdn, additionalResourceType)).To(Equal(resourceTTL))
 			Expect(getMockedComment(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceComment))
@@ -677,11 +677,11 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, dnsv1alpha2.SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceRecords))
 			Expect(getMockedTTL(DnsFqdn, additionalResourceType)).To(Equal(resourceTTL))
 			Expect(getMockedComment(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceComment))
@@ -744,11 +744,11 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, dnsv1alpha2.SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceRecords))
 			Expect(getMockedTTL(DnsFqdn, additionalResourceType)).To(Equal(resourceTTL))
 			Expect(getMockedComment(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceComment))
@@ -810,11 +810,11 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, dnsv1alpha2.SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceRecords))
 			Expect(getMockedTTL(DnsFqdn, additionalResourceType)).To(Equal(resourceTTL))
 			Expect(getMockedComment(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceComment))
@@ -877,11 +877,11 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, dnsv1alpha2.SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceRecords))
 			Expect(getMockedTTL(DnsFqdn, additionalResourceType)).To(Equal(resourceTTL))
 			Expect(getMockedComment(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceComment))
@@ -944,11 +944,11 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, dnsv1alpha2.SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceRecords))
 			Expect(getMockedTTL(DnsFqdn, additionalResourceType)).To(Equal(resourceTTL))
 			Expect(getMockedComment(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceComment))
@@ -1011,11 +1011,11 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+zoneName+".", additionalResourceType, dnsv1alpha2.SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceRecords))
 			Expect(getMockedTTL(DnsFqdn, additionalResourceType)).To(Equal(resourceTTL))
 			Expect(getMockedComment(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceComment))
@@ -1111,11 +1111,11 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, additionalRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+reverseZoneName+".", additionalResourceType, SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(additionalResourceName+"."+reverseZoneName+".", additionalResourceType, dnsv1alpha2.SUCCEEDED_STATUS, additionalResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceRecords))
 			Expect(getMockedTTL(DnsFqdn, additionalResourceType)).To(Equal(resourceTTL))
 			Expect(getMockedComment(DnsFqdn, additionalResourceType)).To(Equal(additionalResourceComment))
@@ -1175,13 +1175,13 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, badTypeRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(badTypeResourceDNSName+"."+zoneRef+".", badTypeResourceType, FAILED_STATUS, badTypeResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(badTypeResourceDNSName+"."+zoneRef+".", badTypeResourceType, dnsv1alpha2.FAILED_STATUS, badTypeResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, badTypeResourceType)).To(Equal([]string{}), "RRset should not have been created in backend")
-			Expect(*createdResource.Status.SyncStatus).To(Equal(FAILED_STATUS), "RRset status should be 'Failed'")
+			Expect(*createdResource.Status.SyncStatus).To(Equal(dnsv1alpha2.FAILED_STATUS), "RRset status should be 'Failed'")
 			Expect(createdResource.GetOwnerReferences()).NotTo(BeEmpty(), "RRset should have setOwnerReference")
 			Expect(createdResource.GetOwnerReferences()[0].Name).To(Equal(zoneRef), "RRset should have setOwnerReference to Zone")
 			Expect(createdResource.GetFinalizers()).To(ContainElement(RESOURCES_FINALIZER_NAME), "RRset should contain the finalizer")
@@ -1238,13 +1238,13 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, badFormatRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(badFormatResourceDNSName+"."+zoneRef+".", badFormatResourceType, FAILED_STATUS, badFormatResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(badFormatResourceDNSName+"."+zoneRef+".", badFormatResourceType, dnsv1alpha2.FAILED_STATUS, badFormatResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, badFormatResourceType)).To(Equal([]string{}), "RRset should not have been created in backend")
-			Expect(*createdResource.Status.SyncStatus).To(Equal(FAILED_STATUS), "RRset status should be 'Failed'")
+			Expect(*createdResource.Status.SyncStatus).To(Equal(dnsv1alpha2.FAILED_STATUS), "RRset status should be 'Failed'")
 			Expect(createdResource.GetOwnerReferences()).NotTo(BeEmpty(), "RRset should have setOwnerReference")
 			Expect(createdResource.GetOwnerReferences()[0].Name).To(Equal(zoneRef), "RRset should have setOwnerReference to Zone")
 			Expect(createdResource.GetFinalizers()).To(ContainElement(RESOURCES_FINALIZER_NAME), "RRset should contain the finalizer")
@@ -1301,13 +1301,13 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, unquotedRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(unquotedResourceDNSName+"."+zoneRef+".", unquotedResourceType, FAILED_STATUS, unquotedResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(unquotedResourceDNSName+"."+zoneRef+".", unquotedResourceType, dnsv1alpha2.FAILED_STATUS, unquotedResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, unquotedResourceType)).To(Equal([]string{}), "RRset should not have been created in backend")
-			Expect(*createdResource.Status.SyncStatus).To(Equal(FAILED_STATUS), "RRset status should be 'Failed'")
+			Expect(*createdResource.Status.SyncStatus).To(Equal(dnsv1alpha2.FAILED_STATUS), "RRset status should be 'Failed'")
 			Expect(createdResource.GetOwnerReferences()).NotTo(BeEmpty(), "RRset should have setOwnerReference")
 			Expect(createdResource.GetOwnerReferences()[0].Name).To(Equal(zoneRef), "RRset should have setOwnerReference to Zone")
 			Expect(createdResource.GetFinalizers()).To(ContainElement(RESOURCES_FINALIZER_NAME), "RRset should contain the finalizer")
@@ -1364,12 +1364,12 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, existingRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(existingResourceDNSName+"."+zoneRef+".", existingResourceType, FAILED_STATUS, existingResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
-			Expect(*createdResource.Status.SyncStatus).To(Equal(FAILED_STATUS), "RRset status should be 'Failed'")
+			Expect(getRrsetMetricWithLabels(existingResourceDNSName+"."+zoneRef+".", existingResourceType, dnsv1alpha2.FAILED_STATUS, existingResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(*createdResource.Status.SyncStatus).To(Equal(dnsv1alpha2.FAILED_STATUS), "RRset status should be 'Failed'")
 			Expect(createdResource.GetFinalizers()).To(ContainElement(RESOURCES_FINALIZER_NAME), "RRset should contain the finalizer")
 			Expect(createdResource.GetFinalizers()).To(ContainElement(METRICS_FINALIZER_NAME), "RRset should contain the metrics finalizer")
 		})
@@ -1426,12 +1426,12 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, pendingRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, PENDING_STATUS, metav1.ConditionFalse)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.PENDING_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(pendingResourceDNSName+"."+pendingZoneName+".", pendingResourceType, PENDING_STATUS, pendingResourceName, pendingResourceNamespace)).To(Equal(1.0), "metric should be 1.0")
-			Expect(*createdResource.Status.SyncStatus).To(Equal(PENDING_STATUS), "RRset status should be 'Pending'")
+			Expect(getRrsetMetricWithLabels(pendingResourceDNSName+"."+pendingZoneName+".", pendingResourceType, dnsv1alpha2.PENDING_STATUS, pendingResourceName, pendingResourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(*createdResource.Status.SyncStatus).To(Equal(dnsv1alpha2.PENDING_STATUS), "RRset status should be 'Pending'")
 			Expect(createdResource.GetFinalizers()).To(ContainElement(METRICS_FINALIZER_NAME), "RRset should contain the metrics finalizer")
 		})
 	})
@@ -1550,7 +1550,7 @@ var _ = Describe("RRset Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, recreatedZone)
-				return err == nil && recreatedZone.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
+				return err == nil && recreatedZone.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/internal/controller/rrset_controller_test.go
+++ b/internal/controller/rrset_controller_test.go
@@ -1126,7 +1126,7 @@ var _ = Describe("RRset Controller", func() {
 	})
 
 	Context("When creating a wrong RRset", func() {
-		It("should reconcile the resource with Failed status", Label("wrong-rrset", "wrong-type"), func() {
+		It("should reconcile the resource with Unprocessable status", Label("wrong-rrset", "wrong-type"), func() {
 			ic := countRrsetsMetrics()
 			ctx := context.Background()
 			// Specific test variables
@@ -1175,21 +1175,21 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, badTypeRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.FAILED_STATUS, metav1.ConditionFalse)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.UNPROCESSABLE_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(badTypeResourceDNSName+"."+zoneRef+".", badTypeResourceType, dnsv1alpha2.FAILED_STATUS, badTypeResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(badTypeResourceDNSName+"."+zoneRef+".", badTypeResourceType, dnsv1alpha2.UNPROCESSABLE_STATUS, badTypeResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, badTypeResourceType)).To(Equal([]string{}), "RRset should not have been created in backend")
-			Expect(*createdResource.Status.SyncStatus).To(Equal(dnsv1alpha2.FAILED_STATUS), "RRset status should be 'Failed'")
+			Expect(*createdResource.Status.SyncStatus).To(Equal(dnsv1alpha2.UNPROCESSABLE_STATUS), "RRset status should be 'Unprocessable'")
 			Expect(createdResource.GetOwnerReferences()).NotTo(BeEmpty(), "RRset should have setOwnerReference")
 			Expect(createdResource.GetOwnerReferences()[0].Name).To(Equal(zoneRef), "RRset should have setOwnerReference to Zone")
-			Expect(createdResource.GetFinalizers()).To(ContainElement(RESOURCES_FINALIZER_NAME), "RRset should contain the finalizer")
+			Expect(createdResource.GetFinalizers()).To(ContainElement(METRICS_FINALIZER_NAME), "RRset should contain the metrics finalizer")
 		})
 	})
 
 	Context("When creating a wrong RRset", func() {
-		It("should reconcile the resource with Failed status", Label("wrong-rrset", "wrong-format"), func() {
+		It("should reconcile the resource with Unprocessable status", Label("wrong-rrset", "wrong-format"), func() {
 			ic := countRrsetsMetrics()
 			ctx := context.Background()
 			// Specific test variables
@@ -1238,21 +1238,21 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, badFormatRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.FAILED_STATUS, metav1.ConditionFalse)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.UNPROCESSABLE_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(badFormatResourceDNSName+"."+zoneRef+".", badFormatResourceType, dnsv1alpha2.FAILED_STATUS, badFormatResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(badFormatResourceDNSName+"."+zoneRef+".", badFormatResourceType, dnsv1alpha2.UNPROCESSABLE_STATUS, badFormatResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, badFormatResourceType)).To(Equal([]string{}), "RRset should not have been created in backend")
-			Expect(*createdResource.Status.SyncStatus).To(Equal(dnsv1alpha2.FAILED_STATUS), "RRset status should be 'Failed'")
+			Expect(*createdResource.Status.SyncStatus).To(Equal(dnsv1alpha2.UNPROCESSABLE_STATUS), "RRset status should be 'Unprocessable'")
 			Expect(createdResource.GetOwnerReferences()).NotTo(BeEmpty(), "RRset should have setOwnerReference")
 			Expect(createdResource.GetOwnerReferences()[0].Name).To(Equal(zoneRef), "RRset should have setOwnerReference to Zone")
-			Expect(createdResource.GetFinalizers()).To(ContainElement(RESOURCES_FINALIZER_NAME), "RRset should contain the finalizer")
+			Expect(createdResource.GetFinalizers()).To(ContainElement(METRICS_FINALIZER_NAME), "RRset should contain the metrics finalizer")
 		})
 	})
 
 	Context("When creating a wrong RRset", func() {
-		It("should reconcile the resource with Failed status", Label("wrong-rrset", "unquoted-txt"), func() {
+		It("should reconcile the resource with Unprocessable status", Label("wrong-rrset", "unquoted-txt"), func() {
 			ic := countRrsetsMetrics()
 			ctx := context.Background()
 			// Specific test variables
@@ -1301,16 +1301,16 @@ var _ = Describe("RRset Controller", func() {
 			createdResource := &dnsv1alpha2.RRset{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, unquotedRRsetLookupKey, createdResource)
-				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.FAILED_STATUS, metav1.ConditionFalse)
+				return err == nil && createdResource.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.UNPROCESSABLE_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(1), "One more metric should have been created")
-			Expect(getRrsetMetricWithLabels(unquotedResourceDNSName+"."+zoneRef+".", unquotedResourceType, dnsv1alpha2.FAILED_STATUS, unquotedResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getRrsetMetricWithLabels(unquotedResourceDNSName+"."+zoneRef+".", unquotedResourceType, dnsv1alpha2.UNPROCESSABLE_STATUS, unquotedResourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedRecordsForType(DnsFqdn, unquotedResourceType)).To(Equal([]string{}), "RRset should not have been created in backend")
-			Expect(*createdResource.Status.SyncStatus).To(Equal(dnsv1alpha2.FAILED_STATUS), "RRset status should be 'Failed'")
+			Expect(*createdResource.Status.SyncStatus).To(Equal(dnsv1alpha2.UNPROCESSABLE_STATUS), "RRset status should be 'Unprocessable'")
 			Expect(createdResource.GetOwnerReferences()).NotTo(BeEmpty(), "RRset should have setOwnerReference")
 			Expect(createdResource.GetOwnerReferences()[0].Name).To(Equal(zoneRef), "RRset should have setOwnerReference to Zone")
-			Expect(createdResource.GetFinalizers()).To(ContainElement(RESOURCES_FINALIZER_NAME), "RRset should contain the finalizer")
+			Expect(createdResource.GetFinalizers()).To(ContainElement(METRICS_FINALIZER_NAME), "RRset should contain the metrics finalizer")
 		})
 	})
 

--- a/internal/controller/rrset_controller_test.go
+++ b/internal/controller/rrset_controller_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/joeig/go-powerdns/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -152,7 +152,7 @@ var _ = Describe("RRset Controller", func() {
 		By("Verifying the resource has been deleted")
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, rssetLookupKey, resource)
-			return errors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}, timeout, interval).Should(BeTrue())
 
 		By("Cleaning up the specific resource instance Zone")
@@ -164,7 +164,7 @@ var _ = Describe("RRset Controller", func() {
 		By("Verifying the resource has been deleted")
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, zoneLookupKey, zone)
-			return errors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}, timeout, interval).Should(BeTrue())
 		// Confirm that resource is deleted in the backend
 		Eventually(func() bool {
@@ -549,7 +549,7 @@ var _ = Describe("RRset Controller", func() {
 			}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, fakeTypeNamespacedName, fakeResource)
-				return errors.IsNotFound(err)
+				return apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -15,10 +15,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -157,14 +157,11 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
+	}
 
-		// The BinaryAssetsDirectory is only required if you want to run the tests directly
-		// without call the makefile target test. If not informed it will look for the
-		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
-		// Note that you must have the required binaries setup under the bin directory to perform
-		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.31.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+	// Retrieve the first found binary directory to allow running tests from IDEs
+	if getFirstFoundEnvTestBinaryDir() != "" {
+		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
 	}
 
 	var err error
@@ -271,6 +268,29 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
+
+// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
+// ENVTEST-based tests depend on specific binaries, usually located in paths set by
+// controller-runtime. When running tests directly (e.g., via an IDE) without using
+// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
+//
+// This function streamlines the process by finding the required binaries, similar to
+// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
+// properly set up, run 'make setup-envtest' beforehand.
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}
 
 type mockClient struct {
 	Zones   mockZonesClient

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/joeig/go-powerdns/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -150,7 +151,11 @@ func TestControllers(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(
+		zap.WriteTo(GinkgoWriter),
+		zap.UseDevMode(true),
+		zap.StacktraceLevel(zapcore.PanicLevel), // Only stacktrace at panic level
+	))
 
 	ctx, cancel = context.WithCancel(context.TODO())
 	By("bootstrapping test environment")

--- a/internal/controller/zone_controller.go
+++ b/internal/controller/zone_controller.go
@@ -111,7 +111,7 @@ func (r *ZoneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &dnsv1alpha2.Zone{}, "Zone.Entry.Name", func(rawObj client.Object) []string {
 		// grab the Zone object, extract its name...
 		var ZoneName string
-		if rawObj.(*dnsv1alpha2.Zone).Status.SyncStatus == nil || *rawObj.(*dnsv1alpha2.Zone).Status.SyncStatus == SUCCEEDED_STATUS {
+		if rawObj.(*dnsv1alpha2.Zone).Status.SyncStatus == nil || *rawObj.(*dnsv1alpha2.Zone).Status.SyncStatus == dnsv1alpha2.SUCCEEDED_STATUS {
 			ZoneName = (rawObj.(*dnsv1alpha2.Zone)).Name
 		}
 		return []string{ZoneName}

--- a/internal/controller/zone_controller_test.go
+++ b/internal/controller/zone_controller_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Zone Controller", func() {
 			zone := &dnsv1alpha2.Zone{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, zone)
-				return err == nil && zone.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && zone.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			Expect(countZonesMetrics()-ic).To(Equal(0), "No more metric should have been created")
 			Expect(getZoneMetricWithLabels(SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
@@ -154,7 +154,7 @@ var _ = Describe("Zone Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, modifiedZone)
-				return err == nil && modifiedZone.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && modifiedZone.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			expectedSerial := initialSerial + uint32(1)
 			Expect(getMockedNameservers(resourceName)).To(Equal(modifiedResourceNameservers), "Nameservers should be equal")
@@ -288,7 +288,7 @@ var _ = Describe("Zone Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, modifiedZone)
-				return err == nil && modifiedZone.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && modifiedZone.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			Expect(getMockedSOAEditAPI(resourceName)).To(Equal(modifiedResourceSOAEditAPI), "SOA-Edit-API should have changed")
 			Expect(*(modifiedZone.Status.Serial)).To(Equal(epochSerial), "Serial should have changed")
@@ -340,7 +340,7 @@ var _ = Describe("Zone Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, updatedZone)
-				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS)
+				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Eventually(func() bool {
@@ -493,7 +493,7 @@ var _ = Describe("Zone Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, updatedZone)
-				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS)
+				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
@@ -531,7 +531,7 @@ var _ = Describe("Zone Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, updatedZone)
-				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS)
+				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/internal/controller/zone_controller_test.go
+++ b/internal/controller/zone_controller_test.go
@@ -110,10 +110,10 @@ var _ = Describe("Zone Controller", func() {
 			zone := &dnsv1alpha2.Zone{}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, zone)
-				return err == nil && zone.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && zone.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			Expect(countZonesMetrics()-ic).To(Equal(0), "No more metric should have been created")
-			Expect(getZoneMetricWithLabels(SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
+			Expect(getZoneMetricWithLabels(dnsv1alpha2.SUCCEEDED_STATUS, resourceName, resourceNamespace)).To(Equal(1.0), "metric should be 1.0")
 			Expect(getMockedKind(resourceName)).To(Equal(resourceKind), "Kind should be equal")
 			Expect(getMockedNameservers(resourceName)).To(Equal(resourceNameservers), "Nameservers should be equal")
 			Expect(getMockedCatalog(resourceName)).To(Equal(resourceCatalog), "Catalog should be equal")
@@ -154,7 +154,7 @@ var _ = Describe("Zone Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, modifiedZone)
-				return err == nil && modifiedZone.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && modifiedZone.IsInExpectedStatus(MODIFIED_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			expectedSerial := initialSerial + uint32(1)
 			Expect(getMockedNameservers(resourceName)).To(Equal(modifiedResourceNameservers), "Nameservers should be equal")
@@ -288,7 +288,7 @@ var _ = Describe("Zone Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, modifiedZone)
-				return err == nil && modifiedZone.IsInExpectedStatus(MODIFIED_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && modifiedZone.IsInExpectedStatus(MODIFIED_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 			Expect(getMockedSOAEditAPI(resourceName)).To(Equal(modifiedResourceSOAEditAPI), "SOA-Edit-API should have changed")
 			Expect(*(modifiedZone.Status.Serial)).To(Equal(epochSerial), "Serial should have changed")
@@ -340,7 +340,7 @@ var _ = Describe("Zone Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, updatedZone)
-				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, SUCCEEDED_STATUS, metav1.ConditionTrue)
+				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.SUCCEEDED_STATUS, metav1.ConditionTrue)
 			}, timeout, interval).Should(BeTrue())
 
 			Eventually(func() bool {
@@ -493,7 +493,7 @@ var _ = Describe("Zone Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, updatedZone)
-				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
+				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
@@ -531,7 +531,7 @@ var _ = Describe("Zone Controller", func() {
 			// Waiting for the resource to be fully modified
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, typeNamespacedName, updatedZone)
-				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, FAILED_STATUS, metav1.ConditionFalse)
+				return err == nil && updatedZone.IsInExpectedStatus(FIRST_GENERATION, dnsv1alpha2.FAILED_STATUS, metav1.ConditionFalse)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/internal/controller/zone_controller_test.go
+++ b/internal/controller/zone_controller_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/joeig/go-powerdns/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -93,7 +93,7 @@ var _ = Describe("Zone Controller", func() {
 		// Waiting for the resource to be fully deleted
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			return errors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}, timeout, interval).Should(BeTrue())
 		// Confirm that resource is deleted in the backend
 		Eventually(func() bool {
@@ -452,7 +452,7 @@ var _ = Describe("Zone Controller", func() {
 			}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, fakeTypeNamespacedName, fakeResource)
-				return errors.IsNotFound(err)
+				return apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})


### PR DESCRIPTION
When a `ClusterRRset`/`RRset` is of an incorrect type, it enters a `Failed` status, and cannot be deleted: the operator gets stuck while reconciling with external resource.
Let's consider not to reconcile as it is in `Failed` status it has never been synchronized