### PR TITLE
refactor: Rename apierrors import for clarity

### DIFF
--- a/internal/controller/clusterrrset_controller.go
+++ b/internal/controller/clusterrrset_controller.go
@@ -15,7 +15,7 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -102,7 +102,7 @@ func (r *ClusterRRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 	err = r.Get(ctx, client.ObjectKey{Namespace: rrset.Namespace, Name: rrset.Spec.ZoneRef.Name}, zone)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Zone not found, remove finalizer and requeue
 			actionOnFinalizer := false
 			if controllerutil.ContainsFinalizer(rrset, RESOURCES_FINALIZER_NAME) {

--- a/internal/controller/clusterrrset_controller_test.go
+++ b/internal/controller/clusterrrset_controller_test.go
@@ -18,7 +18,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -146,7 +146,7 @@ var _ = Describe("ClusterRRset Controller", func() {
 		By("Verifying the resource has been deleted")
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, clusterRrsetLookupKey, resource)
-			return errors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}, timeout, interval).Should(BeTrue())
 
 		By("Cleaning up the specific resource instance Zone")
@@ -158,7 +158,7 @@ var _ = Describe("ClusterRRset Controller", func() {
 		By("Verifying the resource has been deleted")
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, clusterZoneLookupKey, zone)
-			return errors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}, timeout, interval).Should(BeTrue())
 		// Confirm that resource is deleted in the backend
 		Eventually(func() bool {

--- a/internal/controller/clusterzone_controller_test.go
+++ b/internal/controller/clusterzone_controller_test.go
@@ -19,7 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -90,7 +90,7 @@ var _ = Describe("ClusterZone Controller", func() {
 		// Waiting for the resource to be fully deleted
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			return errors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}, timeout, interval).Should(BeTrue())
 		// Confirm that resource is deleted in the backend
 		Eventually(func() bool {

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -19,7 +19,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/joeig/go-powerdns/v3"
 	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -154,7 +154,7 @@ func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified b
 		Message:            conditionMessage,
 	})
 	if err != nil {
-		if errors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			log.Info("Object has been modified, forcing a new reconciliation")
 			return ctrl.Result{Requeue: true}, nil
 		}
@@ -293,7 +293,7 @@ func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1
 
 	// Set OwnerReference
 	if err := ownObject(ctx, zone, gr, scheme, cl, log); err != nil {
-		if errors.IsConflict(err) {
+		if apierrors.IsConflict(err) {
 			log.Info("Conflict on RRSet owner reference, retrying")
 			return ctrl.Result{Requeue: true}, nil
 		}
@@ -535,7 +535,7 @@ func createOrUpdateRrsetExternalResources(ctx context.Context, zone dnsv1alpha2.
 	rrType := powerdns.RRType(rrset.GetSpec().Type)
 	// Looking for a record with same Name and Type
 	records, err := PDNSClient.Records.Get(ctx, zone.GetObjectMeta().Name, name, &rrType)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !apierrors.IsNotFound(err) {
 		return false, err
 	}
 	// An issue exist on GET API Calls, comments for another RRSet are included although we filter

--- a/internal/controller/rrset_controller.go
+++ b/internal/controller/rrset_controller.go
@@ -18,7 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -115,7 +115,7 @@ func (r *RRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 	err = r.Get(ctx, client.ObjectKey{Namespace: rrset.Namespace, Name: rrset.Spec.ZoneRef.Name}, zone)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Zone not found, remove finalizer and requeue
 			actionOnFinalizer := false
 			if controllerutil.ContainsFinalizer(rrset, RESOURCES_FINALIZER_NAME) {

--- a/internal/controller/rrset_controller_test.go
+++ b/internal/controller/rrset_controller_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/joeig/go-powerdns/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -152,7 +152,7 @@ var _ = Describe("RRset Controller", func() {
 		By("Verifying the resource has been deleted")
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, rssetLookupKey, resource)
-			return errors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}, timeout, interval).Should(BeTrue())
 
 		By("Cleaning up the specific resource instance Zone")
@@ -164,7 +164,7 @@ var _ = Describe("RRset Controller", func() {
 		By("Verifying the resource has been deleted")
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, zoneLookupKey, zone)
-			return errors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}, timeout, interval).Should(BeTrue())
 		// Confirm that resource is deleted in the backend
 		Eventually(func() bool {
@@ -549,7 +549,7 @@ var _ = Describe("RRset Controller", func() {
 			}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, fakeTypeNamespacedName, fakeResource)
-				return errors.IsNotFound(err)
+				return apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(countRrsetsMetrics()-ic).To(Equal(0), "No more metric should have been created")

--- a/internal/controller/zone_controller_test.go
+++ b/internal/controller/zone_controller_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/joeig/go-powerdns/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -93,7 +93,7 @@ var _ = Describe("Zone Controller", func() {
 		// Waiting for the resource to be fully deleted
 		Eventually(func() bool {
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			return errors.IsNotFound(err)
+			return apierrors.IsNotFound(err)
 		}, timeout, interval).Should(BeTrue())
 		// Confirm that resource is deleted in the backend
 		Eventually(func() bool {
@@ -452,7 +452,7 @@ var _ = Describe("Zone Controller", func() {
 			}
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, fakeTypeNamespacedName, fakeResource)
-				return errors.IsNotFound(err)
+				return apierrors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})


### PR DESCRIPTION
Rename `k8s.io/apimachinery/pkg/api/errors` import if it coexists with standard `errors` import
