### PR TITLE
refactor: Use helpers to manage Status

### DIFF
--- a/api/v1alpha2/constants.go
+++ b/api/v1alpha2/constants.go
@@ -5,3 +5,17 @@ const (
 	PENDING_STATUS   = "Pending"
 	SUCCEEDED_STATUS = "Succeeded"
 )
+
+const (
+	MISSING_ZONE_REASON            = "ZoneMissing"
+	MISSING_ZONE_MESSAGE           = "Missing Zone:"
+	ZONE_NOT_AVAILABLE_REASON      = "ZoneNotAvailable"
+	ZONE_NOT_AVAILABLE_MESSAGE     = "Zone not available:"
+	DUPLICATED_REASON              = "Duplicated"
+	RRSET_DUPLICATED_MESSAGE       = "At least another ClusterRRset/RRset exists with the same name"
+	SYNCHRONIZATION_FAILED_REASON  = "SynchronizationFailed"
+	SYNCHRONIZATION_FAILED_MESSAGE = "Synchronization failed:"
+	SUCCEEDED_REASON               = "Succeeded"
+	SUCCEEDED_MESSAGE              = "Succeeded"
+	ZONE_DUPLICATED_MESSAGE        = "At least another ClusterZone/Zone exists with the same name"
+)

--- a/api/v1alpha2/generic_rrset.go
+++ b/api/v1alpha2/generic_rrset.go
@@ -13,8 +13,12 @@
 package v1alpha2
 
 import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 )
 
 // +kubebuilder:object:root=false
@@ -34,6 +38,13 @@ type GenericRRset interface {
 	GetStatus() RRsetStatus
 	SetStatus(status RRsetStatus)
 	Copy() GenericRRset
+
+	// Set Status functions
+	SetDuplicated(lastUpdateTime *metav1.Time, name string)
+	SetMissingZone(err error)
+	SetZoneNotAvailable(zoneName string)
+	SetSynchronizationFailed(lastUpdateTime *metav1.Time, err error)
+	SetAvailable(lastUpdateTime *metav1.Time, name string)
 }
 
 // +kubebuilder:object:root:false
@@ -63,6 +74,25 @@ func (c *RRset) SetStatus(status RRsetStatus) {
 func (c *RRset) Copy() GenericRRset {
 	return c.DeepCopy()
 }
+func (c *RRset) SetMissingZone(err error) {
+	setMissingZone(&c.Status, c.Generation, err)
+}
+
+func (c *RRset) SetZoneNotAvailable(zoneName string) {
+	setZoneNotAvailable(&c.Status, c.Generation, zoneName)
+}
+
+func (c *RRset) SetDuplicated(lastUpdateTime *metav1.Time, name string) {
+	setRRsetDuplicated(&c.Status, c.Generation, lastUpdateTime, name)
+}
+
+func (c *RRset) SetSynchronizationFailed(lastUpdateTime *metav1.Time, err error) {
+	setRRsetSynchronizationFailed(&c.Status, c.Generation, lastUpdateTime, err)
+}
+
+func (c *RRset) SetAvailable(lastUpdateTime *metav1.Time, name string) {
+	setRRsetAvailable(&c.Status, c.Generation, lastUpdateTime, name)
+}
 
 // +kubebuilder:object:root:false
 // +kubebuilder:object:generate:false
@@ -90,4 +120,94 @@ func (c *ClusterRRset) SetStatus(status RRsetStatus) {
 
 func (c *ClusterRRset) Copy() GenericRRset {
 	return c.DeepCopy()
+}
+
+func (c *ClusterRRset) SetMissingZone(err error) {
+	setMissingZone(&c.Status, c.Generation, err)
+}
+
+func (c *ClusterRRset) SetZoneNotAvailable(zoneName string) {
+	setZoneNotAvailable(&c.Status, c.Generation, zoneName)
+}
+
+func (c *ClusterRRset) SetDuplicated(lastUpdateTime *metav1.Time, name string) {
+	setRRsetDuplicated(&c.Status, c.Generation, lastUpdateTime, name)
+}
+
+func (c *ClusterRRset) SetSynchronizationFailed(lastUpdateTime *metav1.Time, err error) {
+	setRRsetSynchronizationFailed(&c.Status, c.Generation, lastUpdateTime, err)
+}
+
+func (c *ClusterRRset) SetAvailable(lastUpdateTime *metav1.Time, name string) {
+	setRRsetAvailable(&c.Status, c.Generation, lastUpdateTime, name)
+}
+
+func setMissingZone(status *RRsetStatus, generation int64, err error) {
+	status.SyncStatus = ptr.To(PENDING_STATUS)
+	status.ObservedGeneration = &generation
+	condition := metav1.Condition{
+		Type:               "Available",
+		Status:             metav1.ConditionFalse,
+		LastTransitionTime: metav1.NewTime(time.Now().UTC()),
+		Reason:             MISSING_ZONE_REASON,
+		Message:            MISSING_ZONE_MESSAGE + err.Error(),
+	}
+	meta.SetStatusCondition(&status.Conditions, condition)
+}
+
+func setZoneNotAvailable(status *RRsetStatus, generation int64, zoneName string) {
+	status.SyncStatus = ptr.To(FAILED_STATUS)
+	status.ObservedGeneration = &generation
+	condition := metav1.Condition{
+		Type:               "Available",
+		Status:             metav1.ConditionFalse,
+		LastTransitionTime: metav1.NewTime(time.Now().UTC()),
+		Reason:             ZONE_NOT_AVAILABLE_REASON,
+		Message:            ZONE_NOT_AVAILABLE_MESSAGE + zoneName,
+	}
+	meta.SetStatusCondition(&status.Conditions, condition)
+}
+
+func setRRsetDuplicated(status *RRsetStatus, generation int64, lastUpdateTime *metav1.Time, name string) {
+	status.SyncStatus = ptr.To(FAILED_STATUS)
+	status.ObservedGeneration = &generation
+	status.LastUpdateTime = lastUpdateTime
+	status.DnsEntryName = &name
+	condition := metav1.Condition{
+		Type:               "Available",
+		Status:             metav1.ConditionFalse,
+		LastTransitionTime: *lastUpdateTime,
+		Reason:             DUPLICATED_REASON,
+		Message:            RRSET_DUPLICATED_MESSAGE,
+	}
+	meta.SetStatusCondition(&status.Conditions, condition)
+}
+
+func setRRsetSynchronizationFailed(status *RRsetStatus, generation int64, lastUpdateTime *metav1.Time, err error) {
+	status.SyncStatus = ptr.To(FAILED_STATUS)
+	status.ObservedGeneration = &generation
+	status.LastUpdateTime = lastUpdateTime
+	condition := metav1.Condition{
+		Type:               "Available",
+		Status:             metav1.ConditionFalse,
+		LastTransitionTime: *lastUpdateTime,
+		Reason:             SYNCHRONIZATION_FAILED_REASON,
+		Message:            SYNCHRONIZATION_FAILED_MESSAGE + err.Error(),
+	}
+	meta.SetStatusCondition(&status.Conditions, condition)
+}
+
+func setRRsetAvailable(status *RRsetStatus, generation int64, lastUpdateTime *metav1.Time, name string) {
+	status.SyncStatus = ptr.To(SUCCEEDED_STATUS)
+	status.ObservedGeneration = &generation
+	status.LastUpdateTime = lastUpdateTime
+	status.DnsEntryName = &name
+	condition := metav1.Condition{
+		Type:               "Available",
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: *lastUpdateTime,
+		Reason:             SUCCEEDED_REASON,
+		Message:            SUCCEEDED_MESSAGE,
+	}
+	meta.SetStatusCondition(&status.Conditions, condition)
 }

--- a/api/v1alpha2/generic_zone.go
+++ b/api/v1alpha2/generic_zone.go
@@ -13,8 +13,13 @@
 package v1alpha2
 
 import (
+	"time"
+
+	"github.com/joeig/go-powerdns/v3"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 )
 
 // +kubebuilder:object:root=false
@@ -35,6 +40,11 @@ type GenericZone interface {
 	GetStatus() ZoneStatus
 	SetStatus(status ZoneStatus)
 	Copy() GenericZone
+
+	// Set Status functions
+	SetDuplicated()
+	SetSynchronizationFailed(err error)
+	SetAvailable(zoneRes *powerdns.Zone)
 }
 
 // +kubebuilder:object:root:false
@@ -65,6 +75,18 @@ func (c *Zone) Copy() GenericZone {
 	return c.DeepCopy()
 }
 
+func (c *Zone) SetDuplicated() {
+	setZoneDuplicated(&c.Status, c.Generation)
+}
+
+func (c *Zone) SetSynchronizationFailed(err error) {
+	setZoneSynchronizationFailed(&c.Status, c.Generation, err)
+}
+
+func (c *Zone) SetAvailable(zoneRes *powerdns.Zone) {
+	setZoneAvailable(&c.Status, c.Generation, zoneRes)
+}
+
 // +kubebuilder:object:root:false
 // +kubebuilder:object:generate:false
 var _ GenericZone = &ClusterZone{}
@@ -91,4 +113,64 @@ func (c *ClusterZone) SetStatus(status ZoneStatus) {
 
 func (c *ClusterZone) Copy() GenericZone {
 	return c.DeepCopy()
+}
+
+func (c *ClusterZone) SetDuplicated() {
+	setZoneDuplicated(&c.Status, c.Generation)
+}
+
+func (c *ClusterZone) SetSynchronizationFailed(err error) {
+	setZoneSynchronizationFailed(&c.Status, c.Generation, err)
+}
+
+func (c *ClusterZone) SetAvailable(zoneRes *powerdns.Zone) {
+	setZoneAvailable(&c.Status, c.Generation, zoneRes)
+}
+
+func setZoneDuplicated(status *ZoneStatus, generation int64) {
+	status.SyncStatus = ptr.To(FAILED_STATUS)
+	status.ObservedGeneration = &generation
+	condition := metav1.Condition{
+		Type:               "Available",
+		Status:             metav1.ConditionFalse,
+		LastTransitionTime: metav1.Time{Time: time.Now().UTC()},
+		Reason:             DUPLICATED_REASON,
+		Message:            ZONE_DUPLICATED_MESSAGE,
+	}
+	meta.SetStatusCondition(&status.Conditions, condition)
+}
+
+func setZoneSynchronizationFailed(status *ZoneStatus, generation int64, err error) {
+	status.SyncStatus = ptr.To(FAILED_STATUS)
+	status.ObservedGeneration = &generation
+	condition := metav1.Condition{
+		Type:               "Available",
+		Status:             metav1.ConditionFalse,
+		LastTransitionTime: metav1.Time{Time: time.Now().UTC()},
+		Reason:             SYNCHRONIZATION_FAILED_REASON,
+		Message:            SYNCHRONIZATION_FAILED_MESSAGE + err.Error(),
+	}
+	meta.SetStatusCondition(&status.Conditions, condition)
+}
+
+func setZoneAvailable(status *ZoneStatus, generation int64, zoneRes *powerdns.Zone) {
+	status.SyncStatus = ptr.To(SUCCEEDED_STATUS)
+	status.ObservedGeneration = &generation
+	status.ID = zoneRes.ID
+	status.Name = zoneRes.Name
+	status.Kind = ptr.To(string(ptr.Deref(zoneRes.Kind, "")))
+	status.Serial = zoneRes.Serial
+	status.NotifiedSerial = zoneRes.NotifiedSerial
+	status.EditedSerial = zoneRes.EditedSerial
+	status.Masters = zoneRes.Masters
+	status.DNSsec = zoneRes.DNSsec
+	status.Catalog = zoneRes.Catalog
+	condition := metav1.Condition{
+		Type:               "Available",
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: metav1.Time{Time: time.Now().UTC()},
+		Reason:             SUCCEEDED_REASON,
+		Message:            SUCCEEDED_MESSAGE,
+	}
+	meta.SetStatusCondition(&status.Conditions, condition)
 }

--- a/internal/controller/clusterrrset_controller.go
+++ b/internal/controller/clusterrrset_controller.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -51,10 +50,12 @@ func (r *ClusterRRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// RRset
 	rrset := &dnsv1alpha2.ClusterRRset{}
+	log.V(1).Info("Getting RRset", "ClusterRRset.Name", req.Name)
 	err := r.Get(ctx, req.NamespacedName, rrset)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	log.V(1).Info("RRset found", "RRset", rrset)
 
 	// Initialize variable to represent ClusterRRset situation
 	isModified := rrset.Status.ObservedGeneration != nil && *rrset.Status.ObservedGeneration != rrset.GetGeneration()
@@ -63,13 +64,16 @@ func (r *ClusterRRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if rrset.Status.LastUpdateTime != nil {
 		lastUpdateTime = rrset.Status.LastUpdateTime
 	}
+	log.V(1).Info("ClusterRRset situation", "isModified", isModified, "isDeleted", isDeleted, "lastUpdateTime", lastUpdateTime)
 
 	// Position metrics finalizer as soon as possible
 	if !isDeleted {
+		log.V(1).Info("ClusterRRset not deleted", "RRset.Name", rrset.Name)
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object. This is equivalent
 		// to registering our finalizer.
 		if !controllerutil.ContainsFinalizer(rrset, METRICS_FINALIZER_NAME) {
+			log.V(1).Info("Adding finalizer to ClusterRRset")
 			controllerutil.AddFinalizer(rrset, METRICS_FINALIZER_NAME)
 			lastUpdateTime = &metav1.Time{Time: time.Now().UTC()}
 			if err := r.Update(ctx, rrset); err != nil {
@@ -79,15 +83,19 @@ func (r *ClusterRRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	}
 
-	// When updating a ClusterRRset, if 'Status' is not changed, 'LastTransitionTime' will not be updated
-	// So we delete condition to force new 'LastTransitionTime'
 	original := rrset.DeepCopy()
-	if !isDeleted && isModified {
-		meta.RemoveStatusCondition(&rrset.Status.Conditions, "Available")
+	// Ensure we update the status in case of early return
+	defer func() {
 		if err := r.Status().Patch(ctx, rrset, client.MergeFrom(original)); err != nil {
 			log.Error(err, "unable to patch ClusterRRSet status")
-			return ctrl.Result{}, err
 		}
+	}()
+
+	// When updating a ClusterRRset, if 'Status' is not changed, 'LastTransitionTime' will not be updated
+	// So we delete condition to force new 'LastTransitionTime'
+	if !isDeleted && isModified {
+		log.V(1).Info("Removing Available condition from ClusterRRset")
+		meta.RemoveStatusCondition(&rrset.Status.Conditions, "Available")
 	}
 
 	// Zone
@@ -100,16 +108,20 @@ func (r *ClusterRRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	case "ClusterZone":
 		zone = &dnsv1alpha2.ClusterZone{}
 	}
+	log.V(1).Info("Getting associated Zone", "Zone.Name", rrset.Spec.ZoneRef.Name, "Zone.Kind", rrset.Spec.ZoneRef.Kind)
 	err = r.Get(ctx, client.ObjectKey{Namespace: rrset.Namespace, Name: rrset.Spec.ZoneRef.Name}, zone)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Zone not found, remove finalizer and requeue
+			log.V(1).Info("Zone not found", "Zone.Name", rrset.Spec.ZoneRef.Name)
 			actionOnFinalizer := false
 			if controllerutil.ContainsFinalizer(rrset, RESOURCES_FINALIZER_NAME) {
+				log.V(1).Info("Removing resources finalizer from ClusterRRset")
 				controllerutil.RemoveFinalizer(rrset, RESOURCES_FINALIZER_NAME)
 				actionOnFinalizer = true
 			}
 			if isDeleted && controllerutil.ContainsFinalizer(rrset, METRICS_FINALIZER_NAME) {
+				log.V(1).Info("Removing metrics finalizer from ClusterRRset")
 				controllerutil.RemoveFinalizer(rrset, METRICS_FINALIZER_NAME)
 				// Remove resource metrics
 				removeRrsetMetrics(rrset)
@@ -124,54 +136,32 @@ func (r *ClusterRRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 			// If RRset is under deletion, no need to update its status
 			if !isDeleted {
-				original = rrset.DeepCopy()
-				rrset.Status.SyncStatus = ptr.To(dnsv1alpha2.PENDING_STATUS)
-				rrset.Status.ObservedGeneration = &rrset.Generation
-				meta.SetStatusCondition(&rrset.Status.Conditions, metav1.Condition{
-					Type:               "Available",
-					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.NewTime(time.Now().UTC()),
-					Reason:             RrsetReasonZoneNotAvailable,
-					Message:            RrsetMessageNonExistentZone + err.Error(),
-				})
-				if err := r.Status().Patch(ctx, rrset, client.MergeFrom(original)); err != nil {
-					log.Error(err, "unable to patch RRSet status")
-					return ctrl.Result{}, err
-				}
+				log.V(1).Info("ClusterRRset is not deleted, setting missing zone")
+				rrset.SetMissingZone(err)
 				updateRrsetsMetrics(getRRsetName(rrset), rrset)
 			}
 
 			// Race condition when creating Zone+RRset at the same time
 			// RRset is not created because Zone is not created yet
 			// Requeue after few seconds
+			log.V(1).Info("Requeuing ClusterRRset", "RequeueAfter", 2*time.Second)
 			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 		} else {
 			log.Error(err, "Failed to get zone")
+			rrset.SetZoneNotAvailable(zone.GetName())
 			return ctrl.Result{}, err
 		}
 	}
 	// If a Zone/ClusterZone exists but is in Failed Status
 	zoneIsInFailedStatus := (zone.GetStatus().SyncStatus != nil && *zone.GetStatus().SyncStatus == dnsv1alpha2.FAILED_STATUS)
 	if zoneIsInFailedStatus {
-		original = rrset.DeepCopy()
-		rrset.Status.SyncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
-		rrset.Status.ObservedGeneration = &rrset.Generation
-		meta.SetStatusCondition(&rrset.Status.Conditions, metav1.Condition{
-			Type:               "Available",
-			Status:             metav1.ConditionFalse,
-			LastTransitionTime: metav1.NewTime(time.Now().UTC()),
-			Reason:             RrsetReasonZoneNotAvailable,
-			Message:            RrsetMessageUnavailableZone + zone.GetName(),
-		})
-		if err := r.Status().Patch(ctx, rrset, client.MergeFrom(original)); err != nil {
-			log.Error(err, "unable to patch RRSet status")
-			return ctrl.Result{}, err
-		}
-
+		log.V(1).Info("Zone is in failed status, setting zone not available")
+		rrset.SetZoneNotAvailable(zone.GetName())
 		// Update metrics
 		updateRrsetsMetrics(getRRsetName(rrset), rrset)
 
 		if isDeleted {
+			log.V(1).Info("ClusterRRset is deleted, removing metrics finalizer")
 			if controllerutil.ContainsFinalizer(rrset, METRICS_FINALIZER_NAME) {
 				controllerutil.RemoveFinalizer(rrset, METRICS_FINALIZER_NAME)
 				// Remove resource metrics

--- a/internal/controller/clusterzone_controller.go
+++ b/internal/controller/clusterzone_controller.go
@@ -47,21 +47,26 @@ func (r *ClusterZoneReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Get ClusterZone
 	zone := &dnsv1alpha2.ClusterZone{}
+	log.V(1).Info("Getting ClusterZone", "ClusterZone.Name", req.Name)
 	err := r.Get(ctx, req.NamespacedName, zone)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	log.V(1).Info("ClusterZone found", "ClusterZone", zone)
 
-	// Initialize variable to represent RRset situation
+	// Initialize variable to represent ClusterZone situation
 	isModified := zone.Status.ObservedGeneration != nil && *zone.Status.ObservedGeneration != zone.GetGeneration()
 	isDeleted := !zone.DeletionTimestamp.IsZero()
+	log.V(1).Info("ClusterZone situation", "isModified", isModified, "isDeleted", isDeleted)
 
 	// Position metrics finalizer as soon as possible
 	if !isDeleted {
+		log.V(1).Info("ClusterZone not deleted", "ClusterZone.Name", zone.Name)
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object. This is equivalent
 		// to registering our finalizer.
 		if !controllerutil.ContainsFinalizer(zone, METRICS_FINALIZER_NAME) {
+			log.V(1).Info("Adding finalizer to ClusterZone")
 			controllerutil.AddFinalizer(zone, METRICS_FINALIZER_NAME)
 			if err := r.Update(ctx, zone); err != nil {
 				log.Error(err, "Failed to add finalizer")
@@ -69,16 +74,21 @@ func (r *ClusterZoneReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			}
 		}
 	}
-	// When updating a ClusterZone, if 'Status' is not changed, 'LastTransitionTime' will not be updated
-	// So we delete condition to force new 'LastTransitionTime'
+
 	original := zone.DeepCopy()
-	if !isDeleted && isModified {
-		isModified = true
-		meta.RemoveStatusCondition(&zone.Status.Conditions, "Available")
+	// Ensure we update the status in case of early return
+	defer func() {
 		if err := r.Status().Patch(ctx, zone, client.MergeFrom(original)); err != nil {
 			log.Error(err, "unable to patch ClusterZone status")
-			return ctrl.Result{}, err
 		}
+	}()
+
+	// When updating a ClusterZone, if 'Status' is not changed, 'LastTransitionTime' will not be updated
+	// So we delete condition to force new 'LastTransitionTime'
+	if !isDeleted && isModified {
+		log.V(1).Info("Removing Available condition from ClusterZone")
+		isModified = true
+		meta.RemoveStatusCondition(&zone.Status.Conditions, "Available")
 	}
 
 	return zoneReconcile(ctx, zone, isModified, isDeleted, r.Client, r.PDNSClient, log)

--- a/internal/controller/common.go
+++ b/internal/controller/common.go
@@ -13,6 +13,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -20,7 +21,6 @@ import (
 	"github.com/joeig/go-powerdns/v3"
 	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+//nolint:unparam // Always return ctrl.Result{} is ok
 func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified bool, isDeleted bool, cl client.Client, PDNSClient PdnsClienter, log logr.Logger) (ctrl.Result, error) {
 	isInFailedStatus := (gz.GetStatus().SyncStatus != nil && *gz.GetStatus().SyncStatus == dnsv1alpha2.FAILED_STATUS)
 
@@ -100,29 +101,12 @@ func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified b
 	// 1 Zone (example.com in NS example1) + 1 ClusterZone (example.com)
 	// In that case: len(existingZones.Items) >= 1 AND len(existingClusterZones.Items) >= 1
 	if len(existingZones.Items) > 1 || (len(existingZones.Items) >= 1 && len(existingClusterZones.Items) >= 1) {
-		original := gz.Copy()
-		conditions := gz.GetStatus().Conditions
-		meta.SetStatusCondition(&conditions, metav1.Condition{
-			Type:               "Available",
-			Status:             metav1.ConditionFalse,
-			LastTransitionTime: metav1.Time{Time: time.Now().UTC()},
-			Reason:             ZoneReasonDuplicated,
-			Message:            ZoneMessageDuplicated,
-		})
-		gz.SetStatus(dnsv1alpha2.ZoneStatus{
-			SyncStatus:         ptr.To(dnsv1alpha2.FAILED_STATUS),
-			ObservedGeneration: &gz.GetObjectMeta().Generation,
-			Conditions:         conditions,
-		})
-		if err := cl.Status().Patch(ctx, gz, client.MergeFrom(original)); err != nil {
-			log.Error(err, "unable to patch ClusterZone/Zone status")
-			return ctrl.Result{}, err
-		}
+		gz.SetDuplicated()
 
 		// Update resource metrics
 		updateZonesMetrics(gz)
 
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, fmt.Errorf("zone already exists")
 	}
 
 	// Get zone
@@ -131,13 +115,10 @@ func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified b
 		return ctrl.Result{}, err
 	}
 
-	syncStatus, conditionMessage, conditionReason, conditionStatus, err := zoneExternalResourcesReconcile(ctx, zoneRes, gz, PDNSClient, log)
+	err = zoneExternalResourcesReconcile(ctx, zoneRes, gz, PDNSClient, log)
 	if err != nil {
+		gz.SetSynchronizationFailed(err)
 		return ctrl.Result{}, err
-	}
-
-	if syncStatus == nil {
-		syncStatus = ptr.To(dnsv1alpha2.SUCCEEDED_STATUS)
 	}
 
 	// Update ZoneStatus
@@ -146,20 +127,7 @@ func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified b
 		return ctrl.Result{}, err
 	}
 
-	err = patchZoneStatus(ctx, gz, zoneRes, syncStatus, cl, metav1.Condition{
-		Type:               "Available",
-		LastTransitionTime: metav1.NewTime(time.Now().UTC()),
-		Status:             conditionStatus,
-		Reason:             conditionReason,
-		Message:            conditionMessage,
-	})
-	if err != nil {
-		if apierrors.IsConflict(err) {
-			log.Info("Object has been modified, forcing a new reconciliation")
-			return ctrl.Result{Requeue: true}, nil
-		}
-		return ctrl.Result{}, err
-	}
+	gz.SetAvailable(zoneRes)
 
 	// Update resource metrics
 	updateZonesMetrics(gz)
@@ -169,19 +137,16 @@ func zoneReconcile(ctx context.Context, gz dnsv1alpha2.GenericZone, isModified b
 
 func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1alpha2.GenericZone, isModified bool, isDeleted bool, lastUpdateTime *metav1.Time, scheme *runtime.Scheme, cl client.Client, PDNSClient PdnsClienter, log logr.Logger) (ctrl.Result, error) {
 	isInFailedStatus := (gr.GetStatus().SyncStatus != nil && *gr.GetStatus().SyncStatus == dnsv1alpha2.FAILED_STATUS)
-
-	// initialize syncStatus
-	var syncStatus *string
-	conditionStatus := metav1.ConditionTrue
-	conditionReason := RrsetReasonSynced
-	conditionMessage := RrsetMessageSyncSucceeded
+	log.V(1).Info("RRset situation", "isModified", isModified, "isDeleted", isDeleted, "lastUpdateTime", lastUpdateTime, "isInFailedStatus", isInFailedStatus)
 
 	// examine DeletionTimestamp to determine if object is under deletion
 	if !isDeleted {
+		log.V(1).Info("RRset not deleted", "RRset.Name", gr.GetName())
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object. This is equivalent
 		// to registering our finalizer.
 		if !controllerutil.ContainsFinalizer(gr, RESOURCES_FINALIZER_NAME) {
+			log.V(1).Info("Adding resources finalizer to RRset")
 			controllerutil.AddFinalizer(gr, RESOURCES_FINALIZER_NAME)
 			lastUpdateTime = &metav1.Time{Time: time.Now().UTC()}
 			if err := cl.Update(ctx, gr); err != nil {
@@ -190,9 +155,11 @@ func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1
 			}
 		}
 	} else {
+		log.V(1).Info("RRset is deleted", "RRset.Name", gr.GetName())
 		// The object is being deleted
 		finalizerRemoved := false
 		if controllerutil.ContainsFinalizer(gr, RESOURCES_FINALIZER_NAME) {
+			log.V(1).Info("Removing resources finalizer from RRset")
 			// our finalizer is present, so lets handle any external dependency
 			if err := deleteRrsetExternalResources(ctx, zone, gr, PDNSClient, log); err != nil {
 				// if fail to delete the external resource, return with error
@@ -216,11 +183,20 @@ func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1
 				return ctrl.Result{}, err
 			}
 		}
-		//nolint:ineffassign
-		lastUpdateTime = &metav1.Time{Time: time.Now().UTC()}
 
 		// Stop reconciliation as the item is being deleted
 		return ctrl.Result{}, nil
+	}
+
+	// Set OwnerReference as soon as the Zone is known, so that RRsets in a
+	// Failed status are also owned (and garbage-collected) by their Zone
+	if err := ownObject(ctx, zone, gr, scheme, cl, log); err != nil {
+		if apierrors.IsConflict(err) {
+			log.Info("Conflict on RRSet owner reference, retrying")
+			return ctrl.Result{Requeue: true}, nil
+		}
+		log.Error(err, "Failed to set owner reference")
+		return ctrl.Result{}, err
 	}
 
 	// We cannot exit previously (at the early moments of reconcile), because we have to allow deletion process
@@ -250,54 +226,26 @@ func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1
 	// 1 RRset (test.example.com in NS example1) + 1 ClusterRRset (test.example.com)
 	// In that case: len(existingRRsets.Items) >= 1 AND len(existingClusterRRsets.Items) >= 1
 	if len(existingRRsets.Items) > 1 || (len(existingRRsets.Items) >= 1 && len(existingClusterRRsets.Items) >= 1) {
-		original := gr.Copy()
-		conditions := gr.GetStatus().Conditions
-		meta.SetStatusCondition(&conditions, metav1.Condition{
-			Type:               "Available",
-			Status:             metav1.ConditionFalse,
-			LastTransitionTime: *lastUpdateTime,
-			Reason:             RrsetReasonDuplicated,
-			Message:            RrsetMessageDuplicated,
-		})
 		name := getRRsetName(gr)
-		gr.SetStatus(dnsv1alpha2.RRsetStatus{
-			LastUpdateTime:     lastUpdateTime,
-			DnsEntryName:       &name,
-			SyncStatus:         ptr.To(dnsv1alpha2.FAILED_STATUS),
-			ObservedGeneration: &gr.GetObjectMeta().Generation,
-			Conditions:         conditions,
-		})
-		if err := cl.Status().Patch(ctx, gr, client.MergeFrom(original)); err != nil {
-			log.Error(err, "unable to patch RRSet status")
-			return ctrl.Result{}, err
-		}
+		gr.SetDuplicated(lastUpdateTime, name)
 
 		// Update resource metrics
 		updateRrsetsMetrics(getRRsetName(gr), gr)
 
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, fmt.Errorf("RRset already exists")
 	}
 
 	// Create or Update
-	changed, err := createOrUpdateRrsetExternalResources(ctx, zone, gr, PDNSClient)
-	if err != nil {
-		log.Error(err, "Failed to create or update external resources")
-		syncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
-		conditionStatus = metav1.ConditionFalse
-		conditionReason = RrsetReasonSynchronizationFailed
-		conditionMessage = err.Error()
-	}
+	var changed bool
+	var err error
+	changed, err = createOrUpdateRrsetExternalResources(ctx, zone, gr, PDNSClient)
 	if changed {
 		lastUpdateTime = &metav1.Time{Time: time.Now().UTC()}
 	}
-
-	// Set OwnerReference
-	if err := ownObject(ctx, zone, gr, scheme, cl, log); err != nil {
-		if apierrors.IsConflict(err) {
-			log.Info("Conflict on RRSet owner reference, retrying")
-			return ctrl.Result{Requeue: true}, nil
-		}
-		log.Error(err, "Failed to set owner reference")
+	if err != nil {
+		log.Error(err, "Failed to create or update external resources")
+		gr.SetSynchronizationFailed(lastUpdateTime, err)
+		updateRrsetsMetrics(getRRsetName(gr), gr)
 		return ctrl.Result{}, err
 	}
 
@@ -306,30 +254,8 @@ func rrsetReconcile(ctx context.Context, gr dnsv1alpha2.GenericRRset, zone dnsv1
 	// But, sometimes, Zone reonciliation finish before RRSet update is applied
 	// In that case, the Serial in Zone Status is false
 	// This update permits triggering a new event after RRSet update applied
-	original := gr.Copy()
-	if syncStatus == nil {
-		syncStatus = ptr.To(dnsv1alpha2.SUCCEEDED_STATUS)
-	}
-	conditions := gr.GetStatus().Conditions
-	meta.SetStatusCondition(&conditions, metav1.Condition{
-		Type:               "Available",
-		LastTransitionTime: *lastUpdateTime,
-		Status:             conditionStatus,
-		Reason:             conditionReason,
-		Message:            conditionMessage,
-	})
 	name := getRRsetName(gr)
-	gr.SetStatus(dnsv1alpha2.RRsetStatus{
-		LastUpdateTime:     lastUpdateTime,
-		DnsEntryName:       &name,
-		SyncStatus:         syncStatus,
-		ObservedGeneration: &gr.GetObjectMeta().Generation,
-		Conditions:         conditions,
-	})
-	if err := cl.Status().Patch(ctx, gr, client.MergeFrom(original)); err != nil {
-		log.Error(err, "unable to patch RRSet status")
-		return ctrl.Result{}, err
-	}
+	gr.SetAvailable(lastUpdateTime, name)
 
 	// Metrics calculation
 	updateRrsetsMetrics(getRRsetName(gr), gr)
@@ -426,28 +352,19 @@ func deleteZoneExternalResources(ctx context.Context, zone dnsv1alpha2.GenericZo
 	return nil
 }
 
-func zoneExternalResourcesReconcile(ctx context.Context, zoneRes *powerdns.Zone, gz dnsv1alpha2.GenericZone, PDNSClient PdnsClienter, log logr.Logger) (*string, string, string, metav1.ConditionStatus, error) {
-	// Initialization
-	var syncStatus *string
-	conditionStatus := metav1.ConditionTrue
-	conditionReason := ZoneReasonSynced
-	conditionMessage := ZoneMessageSyncSucceeded
-
+func zoneExternalResourcesReconcile(ctx context.Context, zoneRes *powerdns.Zone, gz dnsv1alpha2.GenericZone, PDNSClient PdnsClienter, log logr.Logger) error {
 	if zoneRes.Name == nil {
 		// If Zone does not exist, create it
 		err := createZoneExternalResources(ctx, gz, PDNSClient, log)
 		if err != nil {
 			log.Error(err, "Failed to create external resources")
-			syncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
-			conditionStatus = metav1.ConditionFalse
-			conditionReason = ZoneReasonSynchronizationFailed
-			conditionMessage = err.Error()
+			return err
 		}
 	} else {
 		// If Zone exists, compare content and update it if necessary
 		ns, err := PDNSClient.Records.Get(ctx, gz.GetObjectMeta().Name, gz.GetObjectMeta().Name, ptr.To(powerdns.RRTypeNS))
 		if err != nil {
-			return nil, "", "", "", err
+			return err
 		}
 
 		// An issue exist on GET API Calls, comments for another RRSet are included although we filter
@@ -477,47 +394,20 @@ func zoneExternalResourcesReconcile(ctx context.Context, zoneRes *powerdns.Zone,
 			}
 			err := updateNsOnZoneExternalResources(ctx, gz, *ttl, PDNSClient, log)
 			if err != nil {
-				syncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
-				conditionStatus = metav1.ConditionFalse
-				conditionReason = ZoneReasonNSSynchronizationFailed
-				conditionMessage = err.Error()
+				log.Error(err, "Failed to update NS in zone")
+				return err
 			}
 		}
 		// Other changes
 		if !zoneIdentical {
 			err := updateZoneExternalResources(ctx, gz, PDNSClient, log)
 			if err != nil {
-				syncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
-				conditionStatus = metav1.ConditionFalse
-				conditionReason = ZoneReasonSynchronizationFailed
-				conditionMessage = err.Error()
+				log.Error(err, "Failed to update zone")
+				return err
 			}
 		}
 	}
-	return syncStatus, conditionMessage, conditionReason, conditionStatus, nil
-}
-
-func patchZoneStatus(ctx context.Context, zone dnsv1alpha2.GenericZone, zoneRes *powerdns.Zone, status *string, cl client.Client, condition metav1.Condition) error {
-	original := zone.Copy()
-
-	kind := string(ptr.Deref(zoneRes.Kind, ""))
-	conditions := zone.GetStatus().Conditions
-	meta.SetStatusCondition(&conditions, condition)
-	zone.SetStatus(dnsv1alpha2.ZoneStatus{
-		ID:                 zoneRes.ID,
-		Name:               zoneRes.Name,
-		Kind:               &kind,
-		Serial:             zoneRes.Serial,
-		NotifiedSerial:     zoneRes.NotifiedSerial,
-		EditedSerial:       zoneRes.EditedSerial,
-		Masters:            zoneRes.Masters,
-		DNSsec:             zoneRes.DNSsec,
-		SyncStatus:         status,
-		Catalog:            zoneRes.Catalog,
-		ObservedGeneration: ptr.To(zone.GetGeneration()),
-		Conditions:         conditions,
-	})
-	return cl.Status().Patch(ctx, zone, client.MergeFrom(original))
+	return nil
 }
 
 func deleteRrsetExternalResources(ctx context.Context, zone dnsv1alpha2.GenericZone, rrset dnsv1alpha2.GenericRRset, PDNSClient PdnsClienter, log logr.Logger) error {

--- a/internal/controller/rrset_controller.go
+++ b/internal/controller/rrset_controller.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -29,17 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	dnsv1alpha2 "github.com/powerdns-operator/powerdns-operator/api/v1alpha2"
-)
-
-const (
-	RrsetReasonZoneNotAvailable      = "ZoneNotAvailable"
-	RrsetReasonSynchronizationFailed = "SynchronizationFailed"
-	RrsetReasonDuplicated            = "RrsetDuplicated"
-	RrsetReasonSynced                = "RrsetSynced"
-	RrsetMessageDuplicated           = "Already existing RRset with the same FQDN"
-	RrsetMessageSyncSucceeded        = "RRset synced with PowerDNS instance"
-	RrsetMessageNonExistentZone      = "non-existent zone:"
-	RrsetMessageUnavailableZone      = "unavailable zone:"
 )
 
 // RRsetReconciler reconciles a RRset object
@@ -60,14 +48,16 @@ func init() {
 
 func (r *RRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
-	log.Info("Reconcile RRset", "Zone.RRset.Name", req.Name)
+	log.Info("Reconcile RRset", "RRset.Name", req.Name)
 
 	// RRset
 	rrset := &dnsv1alpha2.RRset{}
+	log.V(1).Info("Getting RRset", "RRset.Name", req.Name)
 	err := r.Get(ctx, req.NamespacedName, rrset)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	log.V(1).Info("RRset found", "RRset", rrset)
 
 	// Initialize variable to represent RRset situation
 	isModified := rrset.Status.ObservedGeneration != nil && *rrset.Status.ObservedGeneration != rrset.GetGeneration()
@@ -76,13 +66,16 @@ func (r *RRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	if rrset.Status.LastUpdateTime != nil {
 		lastUpdateTime = rrset.Status.LastUpdateTime
 	}
+	log.V(1).Info("RRset situation", "isModified", isModified, "isDeleted", isDeleted, "lastUpdateTime", lastUpdateTime)
 
 	// Position metrics finalizer as soon as possible
 	if !isDeleted {
+		log.V(1).Info("RRset not deleted", "RRset.Name", rrset.Name)
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object. This is equivalent
 		// to registering our finalizer.
 		if !controllerutil.ContainsFinalizer(rrset, METRICS_FINALIZER_NAME) {
+			log.V(1).Info("Adding finalizer to RRset")
 			controllerutil.AddFinalizer(rrset, METRICS_FINALIZER_NAME)
 			lastUpdateTime = &metav1.Time{Time: time.Now().UTC()}
 			if err := r.Update(ctx, rrset); err != nil {
@@ -92,15 +85,19 @@ func (r *RRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		}
 	}
 
-	// When updating a RRset, if 'Status' is not changed, 'LastTransitionTime' will not be updated
-	// So we delete condition to force new 'LastTransitionTime'
 	original := rrset.DeepCopy()
-	if !isDeleted && isModified {
-		meta.RemoveStatusCondition(&rrset.Status.Conditions, "Available")
+	// Ensure we update the status in case of early return
+	defer func() {
 		if err := r.Status().Patch(ctx, rrset, client.MergeFrom(original)); err != nil {
 			log.Error(err, "unable to patch RRSet status")
-			return ctrl.Result{}, err
 		}
+	}()
+
+	// When updating a RRset, if 'Status' is not changed, 'LastTransitionTime' will not be updated
+	// So we delete condition to force new 'LastTransitionTime'
+	if !isDeleted && isModified {
+		log.V(1).Info("Removing Available condition from RRset")
+		meta.RemoveStatusCondition(&rrset.Status.Conditions, "Available")
 	}
 
 	// Zone
@@ -113,16 +110,20 @@ func (r *RRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	case "ClusterZone":
 		zone = &dnsv1alpha2.ClusterZone{}
 	}
+	log.V(1).Info("Getting associated Zone", "Zone.Name", rrset.Spec.ZoneRef.Name, "Zone.Kind", rrset.Spec.ZoneRef.Kind)
 	err = r.Get(ctx, client.ObjectKey{Namespace: rrset.Namespace, Name: rrset.Spec.ZoneRef.Name}, zone)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Zone not found, remove finalizer and requeue
+			log.V(1).Info("Zone not found", "Zone.Name", rrset.Spec.ZoneRef.Name)
 			actionOnFinalizer := false
 			if controllerutil.ContainsFinalizer(rrset, RESOURCES_FINALIZER_NAME) {
+				log.V(1).Info("Removing resources finalizer from RRset")
 				controllerutil.RemoveFinalizer(rrset, RESOURCES_FINALIZER_NAME)
 				actionOnFinalizer = true
 			}
 			if isDeleted && controllerutil.ContainsFinalizer(rrset, METRICS_FINALIZER_NAME) {
+				log.V(1).Info("Removing metrics finalizer from RRset")
 				controllerutil.RemoveFinalizer(rrset, METRICS_FINALIZER_NAME)
 				// Remove resource metrics
 				removeRrsetMetrics(rrset)
@@ -137,54 +138,32 @@ func (r *RRsetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 
 			// If RRset is under deletion, no need to update its status
 			if !isDeleted {
-				original = rrset.DeepCopy()
-				rrset.Status.SyncStatus = ptr.To(dnsv1alpha2.PENDING_STATUS)
-				rrset.Status.ObservedGeneration = &rrset.Generation
-				meta.SetStatusCondition(&rrset.Status.Conditions, metav1.Condition{
-					Type:               "Available",
-					Status:             metav1.ConditionFalse,
-					LastTransitionTime: metav1.NewTime(time.Now().UTC()),
-					Reason:             RrsetReasonZoneNotAvailable,
-					Message:            RrsetMessageNonExistentZone + err.Error(),
-				})
-				if err := r.Status().Patch(ctx, rrset, client.MergeFrom(original)); err != nil {
-					log.Error(err, "unable to patch RRSet status")
-					return ctrl.Result{}, err
-				}
+				log.V(1).Info("RRset is not deleted, setting missing zone")
+				rrset.SetMissingZone(err)
 				updateRrsetsMetrics(getRRsetName(rrset), rrset)
 			}
 
 			// Race condition when creating Zone+RRset at the same time
 			// RRset is not created because Zone is not created yet
 			// Requeue after few seconds
+			log.V(1).Info("Requeuing RRset", "RequeueAfter", 2*time.Second)
 			return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 		} else {
 			log.Error(err, "Failed to get zone")
+			rrset.SetZoneNotAvailable(zone.GetName())
 			return ctrl.Result{}, err
 		}
 	}
 	// If a Zone/ClusterZone exists but is in Failed Status
 	zoneIsInFailedStatus := (zone.GetStatus().SyncStatus != nil && *zone.GetStatus().SyncStatus == dnsv1alpha2.FAILED_STATUS)
 	if zoneIsInFailedStatus {
-		original = rrset.DeepCopy()
-		rrset.Status.SyncStatus = ptr.To(dnsv1alpha2.FAILED_STATUS)
-		rrset.Status.ObservedGeneration = &rrset.Generation
-		meta.SetStatusCondition(&rrset.Status.Conditions, metav1.Condition{
-			Type:               "Available",
-			Status:             metav1.ConditionFalse,
-			LastTransitionTime: metav1.NewTime(time.Now().UTC()),
-			Reason:             RrsetReasonZoneNotAvailable,
-			Message:            RrsetMessageUnavailableZone + zone.GetName(),
-		})
-		if err := r.Status().Patch(ctx, rrset, client.MergeFrom(original)); err != nil {
-			log.Error(err, "unable to patch RRSet status")
-			return ctrl.Result{}, err
-		}
-
+		log.V(1).Info("Zone is in failed status, setting zone not available")
+		rrset.SetZoneNotAvailable(zone.GetName())
 		// Update metrics
 		updateRrsetsMetrics(getRRsetName(rrset), rrset)
 
 		if isDeleted {
+			log.V(1).Info("RRset is deleted, removing metrics finalizer")
 			if controllerutil.ContainsFinalizer(rrset, METRICS_FINALIZER_NAME) {
 				controllerutil.RemoveFinalizer(rrset, METRICS_FINALIZER_NAME)
 				// Remove resource metrics

--- a/internal/controller/zone_controller.go
+++ b/internal/controller/zone_controller.go
@@ -97,7 +97,7 @@ func (r *ZoneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// When updating a Zone, if 'Status' is not changed, 'LastTransitionTime' will not be updated
 	// So we delete condition to force new 'LastTransitionTime'
 	if !isDeleted && isModified {
-		log.V(1).Info("Removing Available condition from ClusterZone")
+		log.V(1).Info("Removing Available condition from Zone")
 		isModified = true
 		meta.RemoveStatusCondition(&zone.Status.Conditions, "Available")
 	}

--- a/internal/controller/zone_controller.go
+++ b/internal/controller/zone_controller.go
@@ -36,15 +36,6 @@ const (
 	ZONE_CONFLICT_CODE  = 409
 )
 
-const (
-	ZoneReasonSynced                  = "ZoneSynced"
-	ZoneMessageSyncSucceeded          = "Zone synced with PowerDNS instance"
-	ZoneReasonSynchronizationFailed   = "SynchronizationFailed"
-	ZoneReasonNSSynchronizationFailed = "NSSynchronizationFailed"
-	ZoneReasonDuplicated              = "ZoneDuplicated"
-	ZoneMessageDuplicated             = "Already existing Zone with the same FQDN"
-)
-
 // ZoneReconciler reconciles a Zone object
 type ZoneReconciler struct {
 	client.Client
@@ -67,21 +58,26 @@ func (r *ZoneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	// Get Zone
 	zone := &dnsv1alpha2.Zone{}
+	log.V(1).Info("Getting Zone", "Zone.Name", req.Name)
 	err := r.Get(ctx, req.NamespacedName, zone)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	log.V(1).Info("Zone found", "Zone", zone)
 
 	// Initialize variable to represent Zone situation
 	isModified := zone.Status.ObservedGeneration != nil && *zone.Status.ObservedGeneration != zone.GetGeneration()
 	isDeleted := !zone.DeletionTimestamp.IsZero()
+	log.V(1).Info("Zone situation", "isModified", isModified, "isDeleted", isDeleted)
 
 	// Position metrics finalizer as soon as possible
 	if !isDeleted {
+		log.V(1).Info("Zone not deleted", "Zone.Name", zone.Name)
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object. This is equivalent
 		// to registering our finalizer.
 		if !controllerutil.ContainsFinalizer(zone, METRICS_FINALIZER_NAME) {
+			log.V(1).Info("Adding finalizer to Zone")
 			controllerutil.AddFinalizer(zone, METRICS_FINALIZER_NAME)
 			if err := r.Update(ctx, zone); err != nil {
 				log.Error(err, "Failed to add finalizer")
@@ -90,16 +86,20 @@ func (r *ZoneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		}
 	}
 
-	// When updating a Zone, if 'Status' is not changed, 'LastTransitionTime' will not be updated
-	// So we delete condition to force new 'LastTransitionTime'
 	original := zone.DeepCopy()
-	if !isDeleted && isModified {
-		isModified = true
-		meta.RemoveStatusCondition(&zone.Status.Conditions, "Available")
+	// Ensure we update the status in case of early return
+	defer func() {
 		if err := r.Status().Patch(ctx, zone, client.MergeFrom(original)); err != nil {
 			log.Error(err, "unable to patch Zone status")
-			return ctrl.Result{}, err
 		}
+	}()
+
+	// When updating a Zone, if 'Status' is not changed, 'LastTransitionTime' will not be updated
+	// So we delete condition to force new 'LastTransitionTime'
+	if !isDeleted && isModified {
+		log.V(1).Info("Removing Available condition from ClusterZone")
+		isModified = true
+		meta.RemoveStatusCondition(&zone.Status.Conditions, "Available")
 	}
 
 	return zoneReconcile(ctx, zone, isModified, isDeleted, r.Client, r.PDNSClient, log)


### PR DESCRIPTION
From now, `Status` are managed through helpers functions.
The updates in the cluster are managed through a `defer` function.
The main principle is "exit as soon as possible"