### PR TITLE
fix!: Make RRset/ClusterRRset zoneRef immutable

### DIFF
--- a/api/v1alpha2/rrset_types.go
+++ b/api/v1alpha2/rrset_types.go
@@ -31,6 +31,7 @@ type RRsetSpec struct {
 	// +optional
 	Comment *string `json:"comment,omitempty"`
 	// ZoneRef reference the zone the RRSet depends on.
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
 	ZoneRef ZoneRef `json:"zoneRef"`
 }
 

--- a/config/crd/bases/dns.cav.enablers.ob_clusterrrsets.yaml
+++ b/config/crd/bases/dns.cav.enablers.ob_clusterrrsets.yaml
@@ -95,6 +95,9 @@ spec:
                 - kind
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
             required:
             - name
             - records

--- a/config/crd/bases/dns.cav.enablers.ob_rrsets.yaml
+++ b/config/crd/bases/dns.cav.enablers.ob_rrsets.yaml
@@ -251,6 +251,9 @@ spec:
                 - kind
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
             required:
             - name
             - records

--- a/docs/guides/clusterrrsets.md
+++ b/docs/guides/clusterrrsets.md
@@ -11,7 +11,7 @@ The `ClusterRRset` specification contains the following fields:
 | ttl | uint32 | Y | DNS TTL of the records, in seconds
 | records | []string | Y | All records in this Resource Record Set
 | comment | string | N | Comment on RRSet |
-| zoneRef | ZoneRef | Y | ZoneRef reference the zone the ClusterRRSet depends on |
+| zoneRef | ZoneRef | Y | ZoneRef reference the zone the ClusterRRSet depends on. This field is immutable: moving a record to another zone requires deleting and recreating the `ClusterRRset` |
 
 The `ZoneRef` specification contains the following fields:
 
@@ -19,6 +19,10 @@ The `ZoneRef` specification contains the following fields:
 | ----- | ---- |:--------:| ----------- |
 | name | string | Y | Name of the `ClusterZone`/`Zone` |
 | kind | string | Y | Kind of zone (Zone/ClusterZone) |
+
+`zoneRef` is immutable as a whole: both `name` and `kind` are frozen once the
+`ClusterRRset` is created. See [Common Issues and Solutions](warnings.md#immutable-zoneref)
+for the rationale and the migration procedure.
 
 ## Example
 

--- a/docs/guides/rrsets.md
+++ b/docs/guides/rrsets.md
@@ -11,7 +11,7 @@ The `RRset` specification contains the following fields:
 | ttl | uint32 | Y | DNS TTL of the records, in seconds
 | records | []string | Y | All records in this Resource Record Set
 | comment | string | N | Comment on RRSet |
-| zoneRef | ZoneRef | Y | ZoneRef reference the zone the RRSet depends on |
+| zoneRef | ZoneRef | Y | ZoneRef reference the zone the RRSet depends on. This field is immutable: moving a record to another zone requires deleting and recreating the `RRset` |
 
 The `ZoneRef` specification contains the following fields:
 
@@ -19,6 +19,10 @@ The `ZoneRef` specification contains the following fields:
 | ----- | ---- |:--------:| ----------- |
 | name | string | Y | Name of the `ClusterZone`/`Zone` |
 | kind | string | Y | Kind of zone (Zone/ClusterZone) |
+
+`zoneRef` is immutable as a whole: both `name` and `kind` are frozen once the
+`RRset` is created. See [Common Issues and Solutions](warnings.md#immutable-zoneref)
+for the rationale and the migration procedure.
 
 ## Example
 

--- a/docs/guides/warnings.md
+++ b/docs/guides/warnings.md
@@ -52,6 +52,28 @@ Parsing record content: Data field in DNS should start with quote (") at positio
 - **Cause**: Referenced zone does not exist or is unhealthy
 - **Solution**: Create the zone first or fix zone issues
 
+### Immutable zoneRef
+- **Error**: `spec.zoneRef: Invalid value: "object": Value is immutable`
+- **Cause**: An attempt to change `spec.zoneRef` (its `name`, its `kind`, or both) on
+  an existing `RRset`/`ClusterRRset`. The field is rejected by the API server, so the
+  resource is never left in an inconsistent state.
+- **Why**: `zoneRef` designates the parent zone that owns the record. Changing it is not
+  a record update but a change of parent: it would move the Kubernetes owner reference
+  (and therefore which zone's deletion garbage-collects the resource), and it would
+  require writing into two different PowerDNS zones. The PowerDNS API applies changes
+  atomically **per zone**, so a cross-zone move cannot be rolled back if its second half
+  fails — the operator would leave an orphaned record behind.
+- **Solution**: Delete the `RRset`/`ClusterRRset` and recreate it with the new `zoneRef`.
+  Be aware this briefly interrupts resolution for that record: the operator removes the
+  record from the old zone on deletion, and only creates it in the new zone once the new
+  resource is reconciled.
+- **Note**: Migrating a zone from `Zone` to `ClusterZone` (or the reverse) keeping the
+  same name also requires recreating its records, since `zoneRef.kind` is frozen too.
+
+Changing `type`, `records`, `ttl` or `comment` does **not** require recreation. Those
+stay within a single zone, and the operator handles whatever is needed on the PowerDNS
+side.
+
 ### API Connectivity
 - **Error**: Resources stuck in "Pending" status
 - **Cause**: PowerDNS API unreachable or authentication failed

--- a/docs/introduction/stability-support.md
+++ b/docs/introduction/stability-support.md
@@ -10,6 +10,15 @@
 
 ## Breaking Changes
 
+### Breaking changes introduced in v0.7.x versions
+
+* `rrset.spec.zoneRef` and `clusterrrset.spec.zoneRef` are now immutable, `kind` and `name` alike
+
+Existing resources remain valid and are not invalidated: the rule is only evaluated on
+update. However, any GitOps pipeline that rewrote `zoneRef` in place will now be rejected
+by the API server. Moving a record to another zone requires deleting and recreating the
+`RRset`/`ClusterRRset` — see [Common Issues and Solutions](../guides/warnings.md#immutable-zoneref).
+
 ### Breaking changes introduced in v0.4.x versions
 
 We noticed lacks of security and delegation possibilities with <=v0.3.x versions, so we decided to split previous `Zone` in 2 differents Custom Resources: 

--- a/internal/controller/clusterrrset_controller_test.go
+++ b/internal/controller/clusterrrset_controller_test.go
@@ -189,6 +189,45 @@ var _ = Describe("ClusterRRset Controller", func() {
 		})
 	})
 
+	Context("When updating ClusterRRset", func() {
+		It("should fail to update the resource ZoneRef Name", Label("clusterrrset-modification", "zoneref-immutability"), func() {
+			ctx := context.Background()
+
+			By("Updating ClusterRRset zoneRef name")
+			resource := &dnsv1alpha2.ClusterRRset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: resourceName,
+				},
+			}
+			_, err := controllerutil.CreateOrUpdate(ctx, k8sClient, resource, func() error {
+				resource.Spec.ZoneRef.Name = "another-zone.org"
+				return nil
+			})
+			Expect(err).To(HaveOccurred(), "ZoneRef name update should be rejected")
+			Expect(err.Error()).To(ContainSubstring("Value is immutable"), "ZoneRef name update should be rejected by the immutability validation rule")
+		})
+	})
+
+	Context("When updating ClusterRRset", func() {
+		It("should fail to update the resource ZoneRef Kind", Label("clusterrrset-modification", "zoneref-kind-immutability"), func() {
+			ctx := context.Background()
+
+			By("Updating ClusterRRset zoneRef kind")
+			resource := &dnsv1alpha2.ClusterRRset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: resourceName,
+				},
+			}
+			// resourceZoneKind is "ClusterZone", so switch to "Zone" to make it an actual change
+			_, err := controllerutil.CreateOrUpdate(ctx, k8sClient, resource, func() error {
+				resource.Spec.ZoneRef.Kind = "Zone"
+				return nil
+			})
+			Expect(err).To(HaveOccurred(), "ZoneRef kind update should be rejected")
+			Expect(err.Error()).To(ContainSubstring("Value is immutable"), "ZoneRef kind update should be rejected by the immutability validation rule")
+		})
+	})
+
 	Context("When creating a RRset with an existing ClusterRRset with same FQDN", func() {
 		It("should reconcile the resource with Failed status", Label("rrset-creation", "existing-clusterrrset"), func() {
 			ctx := context.Background()

--- a/internal/controller/rrset_controller_test.go
+++ b/internal/controller/rrset_controller_test.go
@@ -350,6 +350,46 @@ var _ = Describe("RRset Controller", func() {
 		})
 	})
 
+	Context("When updating RRset", func() {
+		It("should fail to update the resource ZoneRef Name", Label("rrset-modification", "zoneref-immutability"), func() {
+			ctx := context.Background()
+
+			By("Updating RRset zoneRef name")
+			resource := &dnsv1alpha2.RRset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: resourceNamespace,
+				},
+			}
+			_, err := controllerutil.CreateOrUpdate(ctx, k8sClient, resource, func() error {
+				resource.Spec.ZoneRef.Name = "another-zone.org"
+				return nil
+			})
+			Expect(err).To(HaveOccurred(), "ZoneRef name update should be rejected")
+			Expect(err.Error()).To(ContainSubstring("Value is immutable"), "ZoneRef name update should be rejected by the immutability validation rule")
+		})
+	})
+
+	Context("When updating RRset", func() {
+		It("should fail to update the resource ZoneRef Kind", Label("rrset-modification", "zoneref-kind-immutability"), func() {
+			ctx := context.Background()
+
+			By("Updating RRset zoneRef kind")
+			resource := &dnsv1alpha2.RRset{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName,
+					Namespace: resourceNamespace,
+				},
+			}
+			_, err := controllerutil.CreateOrUpdate(ctx, k8sClient, resource, func() error {
+				resource.Spec.ZoneRef.Kind = "ClusterZone"
+				return nil
+			})
+			Expect(err).To(HaveOccurred(), "ZoneRef kind update should be rejected")
+			Expect(err.Error()).To(ContainSubstring("Value is immutable"), "ZoneRef kind update should be rejected by the immutability validation rule")
+		})
+	})
+
 	Context("When existing resource", func() {
 		It("should successfully recreate an existing rrset", Label("rrset-recreation"), func() {
 			ic := countRrsetsMetrics()


### PR DESCRIPTION
ClusterRRset/RRset `ZoneRef` is now immutable. 

Changing `zoneRef` is not a record update, it's a change of parent: it moves the Kubernetes owner reference and requires writing into two different PowerDNS zones. The PowerDNS API applies changes atomically **per zone**, so a cross-zone move can't be rolled back if its second half fails.

On the current code, changing it either loops forever on `AlreadyOwnedError` while orphaning the old record, or — when the target zone doesn't exist — strips the `external-resources` finalizer from a live object, leaving a record no deletion will ever clean up.

## Notes

- `type`, `records`, `ttl` and `comment` stay mutable. Deliberately unchanged: the operator owns intra-zone transitions.
- Existing objects are not invalidated — a transition rule only evaluates on update. GitOps pipelines that rewrote `zoneRef` in place will now be rejected.
- Breaking-changes entry added under **v0.7.x** (next major release)